### PR TITLE
Add the cplocn2atm namelist option to turn on/off ocean feedback to FV3

### DIFF
--- a/atmos_model.F90
+++ b/atmos_model.F90
@@ -1785,7 +1785,7 @@ end subroutine atmos_data_type_chksum
           fldname = 'sea_surface_temperature'
           if (trim(impfield_name) == trim(fldname)) then
             findex  = queryImportFields(fldname)
-            if (importFieldsValid(findex)) then
+            if (importFieldsValid(findex) .and. GFS_control%cplocn2atm) then
 !$omp parallel do default(shared) private(i,j,nb,ix)
               do j=jsc,jec
                 do i=isc,iec

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -629,6 +629,7 @@ module GFS_typedefs
 !--- coupling parameters
     logical              :: cplflx          !< default no cplflx collection
     logical              :: cplice          !< default yes cplice collection (used together with cplflx)
+    logical              :: cplocn2atm      !< default yes ocn->atm coupling
     logical              :: cplwav          !< default no cplwav collection
     logical              :: cplwav2atm      !< default no wav->atm coupling
     logical              :: cplchm          !< default no cplchm collection
@@ -3110,6 +3111,7 @@ module GFS_typedefs
     !--- coupling parameters
     logical              :: cplflx         = .false.         !< default no cplflx collection
     logical              :: cplice         = .true.          !< default yes cplice collection (used together with cplflx)
+    logical              :: cplocn2atm     = .true.          !< default yes cplocn2atm coupling (turn on the feedback from ocn to atm)
     logical              :: cplwav         = .false.         !< default no cplwav collection
     logical              :: cplwav2atm     = .false.         !< default no cplwav2atm coupling
     logical              :: cplchm         = .false.         !< default no cplchm collection
@@ -3577,7 +3579,7 @@ module GFS_typedefs
                                naux3d, aux2d_time_avg, aux3d_time_avg, fhcyc,               &
                                thermodyn_id, sfcpress_id,                                   &
                           !--- coupling parameters
-                               cplflx, cplice, cplwav, cplwav2atm, cplchm,                  &
+                               cplflx, cplice, cplocn2atm, cplwav, cplwav2atm, cplchm,      &
                                cpl_imp_mrg, cpl_imp_dbg,                                    &
                                lsidea,                                                      &
                           !--- radiation parameters
@@ -3855,6 +3857,7 @@ module GFS_typedefs
 !--- coupling parameters
     Model%cplflx           = cplflx
     Model%cplice           = cplice
+    Model%cplocn2atm       = cplocn2atm
     Model%cplwav           = cplwav
     Model%cplwav2atm       = cplwav2atm
     Model%cplchm           = cplchm
@@ -5444,6 +5447,7 @@ module GFS_typedefs
       print *, 'coupling parameters'
       print *, ' cplflx            : ', Model%cplflx
       print *, ' cplice            : ', Model%cplice
+      print *, ' cplocn2atm        : ', Model%cplocn2atm
       print *, ' cplwav            : ', Model%cplwav
       print *, ' cplwav2atm        : ', Model%cplwav2atm
       print *, ' cplchm            : ', Model%cplchm

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -2594,6 +2594,12 @@
   units = flag
   dimensions = ()
   type = logical
+[cplocn2atm]
+  standard_name = flag_for_one_way_ocean_coupling_to_atmosphere
+  long_name = flag controlling ocean coupling to the atmosphere (default on)
+  units = flag
+  dimensions = ()
+  type = logical
 [cplwav]
   standard_name = flag_for_ocean_wave_coupling
   long_name = flag controlling cplwav collection (default off)


### PR DESCRIPTION
Currently, when running coupled configurations/applications (e.g., HAFS or S2S). There is no available option to control one-way coupling to turn off the ocean model component feedback (e.g., SST) to FV3ATM.

Similar to the cplwav2atm namelist option, add a cplocn2atm namelist option to turn on/off the ocean model component feedback (e.g., SST) to the atmosphere model component. This is useful to control the one-way or two-way atmosphere-ocean coupling, as well as to configure different combinations for the atmosphere-ocean-wave coupling in HAFS and/or other applications.
