### PR TITLE
Move cpl_grid_id to FV3 model attributes

### DIFF
--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -649,7 +649,6 @@ module GFS_typedefs
     logical              :: cplwav2atm      !< default no wav->atm coupling
     logical              :: cplchm          !< default no cplchm collection
     logical              :: use_cice_alb    !< default .false. - i.e. don't use albedo imported from the ice model
-    integer              :: cpl_grid_id     !< default grid 1 (parent)
     logical              :: cpl_imp_mrg     !< default no merge import with internal forcings
     logical              :: cpl_imp_dbg     !< default no write import data to file post merge
 
@@ -3131,7 +3130,6 @@ module GFS_typedefs
     logical              :: cplwav2atm     = .false.         !< default no cplwav2atm coupling
     logical              :: cplchm         = .false.         !< default no cplchm collection
     logical              :: use_cice_alb   = .false.         !< default no cice albedo
-    integer              :: cpl_grid_id    = 1
     logical              :: cpl_imp_mrg    = .false.         !< default no merge import with internal forcings
     logical              :: cpl_imp_dbg    = .false.         !< default no write import data to file post merge
 
@@ -3613,7 +3611,7 @@ module GFS_typedefs
                                thermodyn_id, sfcpress_id,                                   &
                           !--- coupling parameters
                                cplflx, cplice, cplocn2atm, cplwav, cplwav2atm, cplchm,      &
-                               cpl_grid_id, cpl_imp_mrg, cpl_imp_dbg,                       &
+                               cpl_imp_mrg, cpl_imp_dbg,                                    &
                                use_cice_alb,                                                &
 #ifdef IDEA_PHYS
                                lsidea, weimer_model, f107_kp_size, f107_kp_interval,        &
@@ -3925,7 +3923,6 @@ module GFS_typedefs
     Model%cplwav2atm       = cplwav2atm
     Model%cplchm           = cplchm
     Model%use_cice_alb     = use_cice_alb
-    Model%cpl_grid_id      = cpl_grid_id
     Model%cpl_imp_mrg      = cpl_imp_mrg
     Model%cpl_imp_dbg      = cpl_imp_dbg
 
@@ -5605,7 +5602,6 @@ module GFS_typedefs
       print *, ' cplwav2atm        : ', Model%cplwav2atm
       print *, ' cplchm            : ', Model%cplchm
       print *, ' use_cice_alb      : ', Model%use_cice_alb
-      print *, ' cpl_grid_id       : ', Model%cpl_grid_id
       print *, ' cpl_imp_mrg       : ', Model%cpl_imp_mrg
       print *, ' cpl_imp_dbg       : ', Model%cpl_imp_dbg
       print *, ' '

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -2657,12 +2657,6 @@
   units = flag
   dimensions = ()
   type = logical
-[cpl_grid_id]
-  standard_name = id_for_coupling_grid
-  long_name = namelist option for setting cpl_grid_id (default 1)
-  units = none
-  dimensions = ()
-  type = integer
 [cpl_imp_mrg]
   standard_name = flag_for_merging_imported_data
   long_name = flag controlling cpl_imp_mrg for imported data (default off)

--- a/fv3_cap.F90
+++ b/fv3_cap.F90
@@ -29,7 +29,7 @@ module fv3gfs_cap_mod
 !
   use module_fv3_config,      only: quilting, output_fh,                     &
                                     nfhout, nfhout_hf, nsout, dt_atmos,      &
-                                    calendar,                                &
+                                    calendar, cpl_grid_id,                   &
                                     cplprint_flag,output_1st_tstep_rst,      &
                                     first_kdt
 
@@ -217,6 +217,12 @@ module fv3gfs_cap_mod
 
     ! query for importState and exportState
     call NUOPC_ModelGet(gcomp, driverClock=clock, importState=importState, exportState=exportState, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+
+    call ESMF_AttributeGet(gcomp, name="cpl_grid_id", value=value, defaultValue="1", &
+                           convention="NUOPC", purpose="Instance", rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+    cpl_grid_id = ESMF_UtilString2Int(value, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
 
     call ESMF_AttributeGet(gcomp, name="ProfileMemory", value=value, defaultValue="false", &

--- a/module_fcst_grid_comp.F90
+++ b/module_fcst_grid_comp.F90
@@ -65,7 +65,7 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
   use module_fv3_io_def,  only: num_pes_fcst, num_files, filename_base,    &
                                 nbdlphys, iau_offset
   use module_fv3_config,  only: dt_atmos, fcst_mpi_comm, fcst_ntasks,      &
-                                quilting, calendar,                        &
+                                quilting, calendar, cpl_grid_id,           &
                                 cplprint_flag, restart_endfcst
 
   use get_stochy_pattern_mod, only: write_stoch_restart_atm
@@ -1066,9 +1066,9 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
 
     call ESMF_VMGet(vm=vm, localPet=mype, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-    if (mype == 0) write(*,*)'fcst_advertise, cpl_grid_id=',GFS_control%cpl_grid_id
+    if (mype == 0) write(*,*)'fcst_advertise, cpl_grid_id=',cpl_grid_id
 
-    call ESMF_GridCompInitialize(fcstGridComp(GFS_control%cpl_grid_id), importState=importState, &
+    call ESMF_GridCompInitialize(fcstGridComp(cpl_grid_id), importState=importState, &
                                  exportState=exportState, phase=3, userrc=urc, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
     if (ESMF_LogFoundError(rcToCheck=urc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__, rcToReturn=rc)) return
@@ -1108,9 +1108,9 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
 
     call ESMF_VMGet(vm=vm, localPet=mype, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-    if (mype == 0) write(*,*)'fcst_realize, cpl_grid_id=',GFS_control%cpl_grid_id
+    if (mype == 0) write(*,*)'fcst_realize, cpl_grid_id=',cpl_grid_id
 
-    call ESMF_GridCompInitialize(fcstGridComp(GFS_control%cpl_grid_id), importState=importState, &
+    call ESMF_GridCompInitialize(fcstGridComp(cpl_grid_id), importState=importState, &
                                  exportState=exportState, phase=4, userrc=urc, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
     if (ESMF_LogFoundError(rcToCheck=urc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__, rcToReturn=rc)) return

--- a/module_fv3_config.F90
+++ b/module_fv3_config.F90
@@ -17,6 +17,7 @@
   integer                  :: first_kdt
   integer                  :: fcst_mpi_comm, fcst_ntasks
 !
+  integer                  :: cpl_grid_id
   logical                  :: cplprint_flag
   logical                  :: quilting, output_1st_tstep_rst
   logical                  :: restart_endfcst


### PR DESCRIPTION
## Description
Set cpl_grid_id using CplGridId in nems.configure (default 1=parent)

## Testing
Case: hafs_nest_cpl_C512_regional_1mvnest_atm_ocn
HPC: Hera
/scratch1/NCEPDEV/hwrf/scrub/Daniel.Rosen/hafs_nest_cpl_C512_regional_1mvnest_atm_ocn/2020082512/13L/forecast


