### PR TITLE
NoahMP LSM and sea ice related updates for HAFS moving nesting

### DIFF
--- a/fv3/moving_nest/fv_moving_nest.F90
+++ b/fv3/moving_nest/fv_moving_nest.F90
@@ -763,7 +763,10 @@ contains
 
     write(parent_str, '(I0)'), tile_num
 
-    if (refine .eq. 1 .and. (tag .eq. 'grid' .or. tag .eq. 'oro_data')) then
+    if (refine .eq. 1 .and.  tag .eq. 'sfc_data') then
+      ! 
+      grid_filename = trim(trim(surface_dir) // '/../' // trim(tag) // '.nc')
+    elseif (refine .eq. 1 .and. (tag .eq. 'grid' .or. tag .eq. 'oro_data')) then
       ! For 1x files in INPUT directory; go at the symbolic link
       grid_filename = trim(trim(surface_dir) // '/' // trim(tag) // '.tile' // trim(parent_str) // '.nc')
     else
@@ -890,7 +893,16 @@ contains
     endif
 
     ! Read in coarse resolution land sea mask to use for masked interpolations; factor in lakes as well
-    call mn_static_read_hires(npx, npy, refine, pelist, surface_dir, "oro_data", "slmsk", static_ls%ls_mask_grid,  tile_num)
+
+    if (refine .eq. 1 .and. tile_num .eq. 1) then
+      ! Read in coarse parent slmask from sfc_data.nc -- this will have land/sea/sea ice mask
+      print '("[INFO] WDR STATIC_READ_LS parent sfc_data npe=",I0)', mpp_pe()
+      call mn_static_read_hires(npx, npy, refine, pelist, surface_dir, "sfc_data", "slmsk", static_ls%ls_mask_grid,  tile_num)
+    else
+      print '("[INFO] WDR STATIC_READ_LS other oro_data npe=",I0)', mpp_pe()
+      call mn_static_read_hires(npx, npy, refine, pelist, surface_dir, "oro_data", "slmsk", static_ls%ls_mask_grid,  tile_num)
+    endif
+
     call mn_static_read_hires(npx, npy, refine, pelist, surface_dir, "oro_data", "land_frac", static_ls%land_frac_grid,  tile_num)
 
     !! Lat lons for debugging
@@ -910,7 +922,7 @@ contains
     character(len=*), intent(in)       :: surface_dir            !< Surface directory
     integer, intent(in) :: npx, npy, refine, tile_num, month     !< Number of x,y points and nest refinement, (parent) tile number
 
-    call mn_static_read_hires(npx, npy, refine, pelist, surface_dir, "substrate_temperature", "substrate_temperature", static_fix%deep_soil_temp_grid, tile_num)
+    call mn_static_read_hires(npx, npy, refine, pelist, trim(surface_dir), "substrate_temperature", "substrate_temperature", static_fix%deep_soil_temp_grid, tile_num)
     ! set any -999s to +4C
     call mn_replace_low_values(static_fix%deep_soil_temp_grid, -100.0, 277.0)
 

--- a/fv3/moving_nest/fv_moving_nest_main.F90
+++ b/fv3/moving_nest/fv_moving_nest_main.F90
@@ -99,7 +99,7 @@ module fv_moving_nest_main_mod
   !------------------------------------
 
   use fv_moving_nest_types_mod, only: allocate_fv_moving_nest_prog_type, allocate_fv_moving_nest_physics_type
-  use fv_moving_nest_types_mod, only: deallocate_fv_moving_nests
+  use fv_moving_nest_types_mod, only: deallocate_fv_moving_nests, mn_set_leading_edge
   use fv_moving_nest_types_mod, only: Moving_nest
   use fv_moving_nest_types_mod, only: mn_apply_lakes, mn_overwrite_with_nest_init_values, alloc_set_facwf
   use fv_moving_nest_types_mod, only: mn_static_overwrite_ls_from_nest, mn_static_overwrite_fix_from_nest
@@ -940,6 +940,10 @@ contains
       jstart_coarse = global_nest_domain%jstart_coarse(nest_num)
       jend_coarse = global_nest_domain%jend_coarse(nest_num)
 
+      if (is_fine_pe) then
+        call mn_set_leading_edge(Moving_nest(child_grid_num)%mn_phys, isd, ied, jsd, jed, ioffset, joffset)
+      endif
+      
       ! Allocate the local weight arrays.  TODO OPTIMIZE change to use the ones from the gridstruct
       if (is_fine_pe) then
         allocate(wt_h(Atm(child_grid_num)%bd%isd:Atm(child_grid_num)%bd%ied, Atm(child_grid_num)%bd%jsd:Atm(child_grid_num)%bd%jed, 4))

--- a/fv3/moving_nest/fv_moving_nest_main.F90
+++ b/fv3/moving_nest/fv_moving_nest_main.F90
@@ -939,7 +939,7 @@ contains
       iend_coarse = global_nest_domain%iend_coarse(nest_num)
       jstart_coarse = global_nest_domain%jstart_coarse(nest_num)
       jend_coarse = global_nest_domain%jend_coarse(nest_num)
-      
+
       ! Allocate the local weight arrays.  TODO OPTIMIZE change to use the ones from the gridstruct
       if (is_fine_pe) then
         allocate(wt_h(Atm(child_grid_num)%bd%isd:Atm(child_grid_num)%bd%ied, Atm(child_grid_num)%bd%jsd:Atm(child_grid_num)%bd%jed, 4))
@@ -951,7 +951,7 @@ contains
         allocate(wt_v(Atm(child_grid_num)%bd%isd:Atm(child_grid_num)%bd%ied+1, Atm(child_grid_num)%bd%jsd:Atm(child_grid_num)%bd%jed, 4))
         wt_v = real_snan
 
-	! Fill in the local weights with the ones from Atm just to be safe
+        ! Fill in the local weights with the ones from Atm just to be safe
         call fill_weight_grid(wt_h, Atm(n)%neststruct%wt_h)
         call fill_weight_grid(wt_u, Atm(n)%neststruct%wt_u)
         call fill_weight_grid(wt_v, Atm(n)%neststruct%wt_v)

--- a/fv3/moving_nest/fv_moving_nest_main.F90
+++ b/fv3/moving_nest/fv_moving_nest_main.F90
@@ -939,10 +939,6 @@ contains
       iend_coarse = global_nest_domain%iend_coarse(nest_num)
       jstart_coarse = global_nest_domain%jstart_coarse(nest_num)
       jend_coarse = global_nest_domain%jend_coarse(nest_num)
-
-      if (is_fine_pe) then
-        call mn_set_leading_edge(Moving_nest(child_grid_num)%mn_phys, isd, ied, jsd, jed, ioffset, joffset)
-      endif
       
       ! Allocate the local weight arrays.  TODO OPTIMIZE change to use the ones from the gridstruct
       if (is_fine_pe) then
@@ -1322,6 +1318,10 @@ contains
            enddo
          enddo
        endif
+
+      if (is_fine_pe) then
+        call mn_set_leading_edge(Moving_nest(child_grid_num)%mn_phys, isd, ied, jsd, jed, delta_i_c, delta_j_c)
+      endif
 
       call mn_prog_apply_temp_variables(Atm, n, child_grid_num, is_fine_pe, npz)
       call mn_phys_apply_temp_variables(Atm, Atm_block, GFS_control, GFS_sfcprop, GFS_tbd, GFS_cldprop, GFS_intdiag, n, child_grid_num, is_fine_pe, npz)

--- a/fv3/moving_nest/fv_moving_nest_physics.F90
+++ b/fv3/moving_nest/fv_moving_nest_physics.F90
@@ -119,6 +119,95 @@ module fv_moving_nest_physics_mod
 
 contains
 
+  subroutine mn_phys_apply_coarse_seaice(Atm, n, mn_static, ioffset, joffset, refine)
+    type(fv_atmos_type), intent(inout),allocatable   :: Atm(:)              !< Array of atmospheric data
+    integer, intent(in)                              :: n                   !< Current grid number
+    type(mn_surface_grids), intent(in)               :: mn_static           !< Static surface data
+    integer, intent(in)                              :: ioffset, joffset    !< Current nest offset in i,j direction
+    integer, intent(in)                              :: refine              !< Nest refinement ratio
+
+    integer                 :: i_pe, j_pe               ! indices of the nest on this PE
+    integer                 :: i_idx, j_idx
+    integer                 :: i_parent, j_parent       ! parent indices
+    integer                 :: this_pe, halo
+
+    integer                 :: i,j, num_seaice
+
+    integer, parameter :: M_WATER = 0, M_LAND = 1, M_SEAICE = 2
+
+    this_pe = mpp_pe()
+    ! Should only be run for a fine PE
+
+    !print '("[INFO] MASK BEGIN inside mn_phys_apply_coarse_seaice npe=",I0," n=",I0," refine=",I0," ioffset=",I0," joffset=",I0)', this_pe, n, refine, ioffset, joffset
+    ! Setup local land sea mask grid for masked interpolations
+    ! These are grid centers, not corners
+
+    halo = 3
+
+    num_seaice = 0
+
+    do i = lbound(mn_static%parent_ls%ls_mask_grid,1), ubound(mn_static%parent_ls%ls_mask_grid,1)
+      do j = lbound(mn_static%parent_ls%ls_mask_grid,2), ubound(mn_static%parent_ls%ls_mask_grid,2)
+        if (mn_static%parent_ls%ls_mask_grid(i, j) .eq. M_SEAICE) num_seaice = num_seaice + 1
+      enddo
+    enddo
+
+    !print '("[INFO] MASK ICE npe=",I0," parent_ls num_seaice=",I0)',this_pe, num_seaice
+
+
+    num_seaice = 0
+
+    do i = lbound(mn_static%fp_ls%ls_mask_grid,1), ubound(mn_static%fp_ls%ls_mask_grid,1)
+      do j = lbound(mn_static%fp_ls%ls_mask_grid,2), ubound(mn_static%fp_ls%ls_mask_grid,2)
+        if (mn_static%fp_ls%ls_mask_grid(i, j) .eq. M_SEAICE) num_seaice = num_seaice + 1
+      enddo
+    enddo
+
+    !print '("[INFO] MASK ICE npe=",I0," fp_ls num_seaice=",I0)',this_pe, num_seaice
+
+    do i_pe = Atm(n)%bd%isd, Atm(n)%bd%ied
+      do j_pe = Atm(n)%bd%jsd, Atm(n)%bd%jed
+        i_idx = (ioffset-1)*refine + i_pe
+        j_idx = (joffset-1)*refine + j_pe
+
+        ! Fortran integer division truncates the fractional parts
+        i_parent = ioffset + (i_pe + 3)/refine
+        j_parent = joffset + (j_pe + 3)/refine
+        if (Moving_nest(n)%mn_phys%slmsk(i_pe, j_pe) .eq. M_WATER) then
+          if (mn_static%parent_ls%ls_mask_grid(i_parent, j_parent) .eq. M_SEAICE) then
+            !print '("[INFO] WDR COARSE_SEAICE AA npe=",I0," i_pe=",I0," j_pe=",I0)', this_pe, i_pe, j_pe
+            Moving_nest(n)%mn_phys%slmsk(i_pe, j_pe) = M_SEAICE
+            !print '("[INFO] WDR COARSE_SEAICE ZZ npe=",I0," i_pe=",I0," j_pe=",I0)', this_pe, i_pe, j_pe
+
+            !print '("[INFO] WDR COARSE_SEAICE Z1 npe=",I0," parent geolat_grid(",I0,"-",I0,",",I0,"-",I0,") i_parent=",I0," j_parent=",I0)', this_pe, lbound(mn_static%parent_ls%geolat_grid,1), ubound(mn_static%parent_ls%geolat_grid,1), lbound(mn_static%parent_ls%geolat_grid,2), ubound(mn_static%parent_ls%geolat_grid,2), i_parent, j_parent
+
+            !print '("[INFO] WDR COARSE_SEAICE Z1 npe=",I0," fp geolat_grid(",I0,",",I0,")")', this_pe, ubound(mn_static%fp_ls%geolat_grid,1), ubound(mn_static%fp_ls%geolat_grid,2)
+
+            !print '("[INFO] WDR COARSE_SEAICE Z1 npe=",I0," nest geolat_grid(",I0,"-",I0,",",I0,"-",I0,") i_pe=",I0," j_pe=",I0)', this_pe, lbound(mn_static%nest_ls%geolat_grid,1), ubound(mn_static%nest_ls%geolat_grid,1), lbound(mn_static%nest_ls%geolat_grid,2), ubound(mn_static%nest_ls%geolat_grid,2), i_pe, j_pe
+
+            !if (i_pe .ge. lbound(mn_static%nest_ls%geolat_grid,1) .and. i_pe .le.  ubound(mn_static%nest_ls%geolat_grid,1) .and. j_pe .ge. lbound(mn_static%nest_ls%geolat_grid,2) .and. j_pe .le.  ubound(mn_static%nest_ls%geolat_grid,2) ) then
+              !print '("[INFO] WDR COARSE_SEAICE INSIDE npe=",I0," i_pe=",I0," j_pe=",I0)', this_pe, i_pe, j_pe
+              !print '("[INFO] WDR COARSE_SEAICE npe=",I0," parent latlon ",F8.3,","F8.3," nest latlon ",F8.3,","F8.3)', this_pe, &
+              !    mn_static%parent_ls%geolat_grid(i_parent, j_parent), mn_static%parent_ls%geolon_grid(i_parent, j_parent), &
+              !    mn_static%nest_ls%geolat_grid(i_pe, j_pe), mn_static%nest_ls%geolon_grid(i_pe, j_pe)
+            !endif
+
+
+            !print '("[INFO] WDR COARSE_SEAICE npe=",I0," parent cell ",F8.3,","F8.3," nest cell ",F8.3,","F8.3)', this_pe, &
+            !    mn_static%parent_ls%geolat_grid(i_parent, j_parent), mn_static%parent_ls%geolon_grid(i_parent, j_parent), &
+            !    mn_static%nest_ls%geolat_grid(i_parent, j_parent), mn_static%nest_ls%geolon_grid(i_parent, j_parent)
+          endif
+        endif
+      enddo
+    enddo
+
+    !print '("[INFO] MASK END inside mn_phys_apply_coarse_seaice npe=",I0)', this_pe
+
+  end subroutine mn_phys_apply_coarse_seaice
+
+
+
+
 
   subroutine mn_phys_set_slmsk(Atm, n, mn_static, ioffset, joffset, refine)
     type(fv_atmos_type), intent(inout),allocatable   :: Atm(:)              !< Array of atmospheric data
@@ -154,13 +243,20 @@ contains
     integer, intent(in)                              :: ioffset, joffset    !< Current nest offset in i,j direction
     integer, intent(in)                              :: refine              !< Nest refinement ratio
 
+    integer, parameter :: M_WATER = 0, M_LAND = 1, M_SEAICE = 2
+
     ! For iterating through physics/surface vector data
     integer                 :: nb, blen, ix, i_pe, j_pe, i_idx, j_idx, im
     real(kind=kind_phys)    :: phys_oro
+    integer                 :: cell_slmsk
+    integer                 :: this_pe
+
+    this_pe = mpp_pe()
 
     !print '("[INFO] MASK inside mn_phys_reset_sfc_props npe=",I0)', mpp_pe()
     call mn_phys_set_slmsk(Atm, n, mn_static, ioffset, joffset, refine)
 
+    call mn_phys_apply_coarse_seaice(Atm, n, mn_static, ioffset, joffset, refine)
     !  Reset the variables from the fix_sfc files
     im = 0
     do nb = 1,Atm_block%nblks
@@ -175,19 +271,39 @@ contains
         im = im + 1
 
         ! Reset the land sea mask from the hires parent data
-        GFS_Sfcprop%slmsk(im) = mn_static%fp_ls%ls_mask_grid(i_idx, j_idx)
+        !GFS_Sfcprop%slmsk(im) = mn_static%fp_ls%ls_mask_grid(i_idx, j_idx)
+        cell_slmsk = Moving_nest(n)%mn_phys%slmsk(i_pe, j_pe)
+        GFS_Sfcprop%slmsk(im) = cell_slmsk
 
         !  IFD values are 0 for land, and 1 for oceans/lakes -- reverse of the land sea mask
         !  Land Sea Mask has values of 0 for oceans/lakes, 1 for land, 2 for sea ice
         !  TODO figure out what ifd should be for sea ice
-        if (mn_static%fp_ls%ls_mask_grid(i_idx, j_idx) .eq. 1 ) then
+
+        ! ICEFIX
+        ! ccpp/physics/physics/Interstitials/UFS_SCM_NEPTUNE/sfcsub.F
+        !     sli .. land/sea/sea-ice mask. (1/0/2 respectively)
+        ! Seems to be slimsk
+
+        ! Process land-sea-ice mask points
+
+        !if (mn_static%fp_ls%ls_mask_grid(i_idx, j_idx) .eq. M_LAND ) then  ! Land
+        if (cell_slmsk .eq. M_LAND ) then  ! Land
           if (move_nsst) GFS_Sfcprop%ifd(im) = 0         ! Land
           GFS_Sfcprop%oceanfrac(im) = 0   ! Land -- TODO permit fractions
           GFS_Sfcprop%landfrac(im) = 1    ! Land -- TODO permit fractions
-        else
+          GFS_Sfcprop%fice(im) = 0        ! ice fraction over open water grid
+        !else if (mn_static%fp_ls%ls_mask_grid(i_idx, j_idx) .eq. M_WATER ) then   ! Ocean
+        else if (cell_slmsk .eq. M_WATER ) then   ! Ocean
           if (move_nsst) GFS_Sfcprop%ifd(im) = 1         ! Ocean
           GFS_Sfcprop%oceanfrac(im) = 1   ! Ocean -- TODO permit fractions
           GFS_Sfcprop%landfrac(im) = 0    ! Ocean -- TODO permit fractions
+          GFS_Sfcprop%fice(im) = 0        ! ice fraction over open water grid
+        !else if (mn_static%fp_ls%ls_mask_grid(i_idx, j_idx) .eq. M_SEAICE ) then     ! Sea Ice
+        else if (cell_slmsk .eq. M_SEAICE ) then     ! Sea Ice
+          if (move_nsst) GFS_Sfcprop%ifd(im) = 0         ! For Sea ice - ifd is set to Land 0, checked in sfc files
+          GFS_Sfcprop%oceanfrac(im) = 0   ! sea ice -- TODO permit fractions
+          GFS_Sfcprop%landfrac(im) = 0    ! sea ice -- TODO permit fractions
+          GFS_Sfcprop%fice(im) = 1        ! ice fraction over open water grid
         endif
 
         GFS_Sfcprop%tg3(im) = mn_static%fp_fix%deep_soil_temp_grid(i_idx, j_idx)
@@ -499,6 +615,16 @@ contains
             mn_phys%tsnoxy(i,j,k)     = GFS_sfcprop%tsnoxy(im,k)
           enddo
 
+          ! ICEFIX handle tiice
+          do k = 1, GFS_control%kice
+            mn_phys%tiice(i,j,k)    = GFS_sfcprop%tiice(im,k)
+          enddo
+          mn_phys%tisfc(i,j)      = GFS_sfcprop%tisfc(im)
+          mn_phys%sncovr(i,j)     = GFS_sfcprop%sncovr(im)
+
+          mn_phys%fice(i,j)      = GFS_sfcprop%fice(im)
+          mn_phys%hice(i,j)      = GFS_sfcprop%hice(im)
+
           mn_phys%snowd(i,j)      = GFS_sfcprop%snowd(im)
           mn_phys%weasd(i,j)      = GFS_sfcprop%weasd(im)
 
@@ -753,6 +879,21 @@ contains
             if (GFS_sfcprop%snowd(im) == 0.0 .and. GFS_sfcprop%weasd(im) /= 0.0) then
               GFS_sfcprop%snowd(im) = GFS_sfcprop%weasd(im)/10.0
             endif
+
+            ! ICEFIX handle tiice
+            do k = 1, GFS_control%kice
+              GFS_sfcprop%tiice(im,k) = mn_phys%tiice(i,j,k)
+            enddo
+            if (mn_phys%tisfc(i,j) .lt. 240.0 .or. mn_phys%tisfc(i,j) .gt. 285.0 ) then
+              mn_phys%tisfc(i,j) = 273.15 - 5.0
+            endif
+            GFS_sfcprop%tisfc(im) = mn_phys%tisfc(i,j)
+            GFS_sfcprop%sncovr(im) = mn_phys%sncovr(i,j)
+
+            GFS_sfcprop%fice(im) = mn_phys%fice(i,j)
+            GFS_sfcprop%hice(im) = mn_phys%hice(i,j)
+
+
 
             do k = 1, GFS_control%lsoil
               GFS_sfcprop%smoiseq(im,k) = mn_phys%smoiseq(i,j,k)
@@ -1389,6 +1530,26 @@ contains
           is_fine_pe, nest_domain, position, GFS_control%lsnow_lsm_lbound, GFS_control%lsoil, &
           mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, zsns_default)
 
+
+      ! ICEFIX tiice
+      call fill_nest_halos_from_parent_masked("tiice", mn_phys%tiice, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
+	  Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
+          is_fine_pe, nest_domain, position, 1, 2, & !! kice
+          mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_SEAICE, mn_phys%ts)
+      call fill_nest_halos_from_parent_masked("tisfc", mn_phys%tisfc, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
+          Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_SEAICE, mn_phys%ts)
+      call fill_nest_halos_from_parent_masked("sncovr", mn_phys%sncovr, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
+          Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0)
+
+      call fill_nest_halos_from_parent_masked("fice", mn_phys%fice, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
+          Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_SEAICE, 1.0D0)
+      call fill_nest_halos_from_parent_masked("hice", mn_phys%hice, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
+          Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_SEAICE, 0.1D0)
+
     endif
 
   end subroutine mn_phys_fill_nest_halos_from_parent
@@ -1517,6 +1678,13 @@ contains
       call mn_var_fill_intern_nest_halos(mn_phys%weasd, domain_fine, is_fine_pe)
       call mn_var_fill_intern_nest_halos(mn_phys%smoiseq, domain_fine, is_fine_pe)
       call mn_var_fill_intern_nest_halos(mn_phys%zsnsoxy, domain_fine, is_fine_pe)
+
+      call mn_var_fill_intern_nest_halos(mn_phys%tiice, domain_fine, is_fine_pe)
+      call mn_var_fill_intern_nest_halos(mn_phys%tisfc, domain_fine, is_fine_pe)
+      call mn_var_fill_intern_nest_halos(mn_phys%sncovr, domain_fine, is_fine_pe)
+
+      call mn_var_fill_intern_nest_halos(mn_phys%fice, domain_fine, is_fine_pe)
+      call mn_var_fill_intern_nest_halos(mn_phys%hice, domain_fine, is_fine_pe)
 
     endif
 
@@ -1758,6 +1926,18 @@ contains
           delta_i_c, delta_j_c, x_refine, y_refine, is_fine_pe, nest_domain, position)
       call mn_var_shift_data(mn_phys%zsnsoxy, interp_type, wt_h, Atm(child_grid_num)%neststruct%ind_h, &
           delta_i_c, delta_j_c, x_refine, y_refine, is_fine_pe, nest_domain, position, GFS_control%lsnow_lsm_lbound, GFS_control%lsoil)
+
+      ! ICEFIX
+      call mn_var_shift_data(mn_phys%tiice, interp_type, wt_h, Atm(child_grid_num)%neststruct%ind_h, &
+          delta_i_c, delta_j_c, x_refine, y_refine, is_fine_pe, nest_domain, position, 1, GFS_control%kice)
+      call mn_var_shift_data(mn_phys%tisfc, interp_type, wt_h, Atm(child_grid_num)%neststruct%ind_h, &
+          delta_i_c, delta_j_c, x_refine, y_refine, is_fine_pe, nest_domain, position)
+      call mn_var_shift_data(mn_phys%sncovr, interp_type, wt_h, Atm(child_grid_num)%neststruct%ind_h, &
+          delta_i_c, delta_j_c, x_refine, y_refine, is_fine_pe, nest_domain, position)
+      call mn_var_shift_data(mn_phys%fice, interp_type, wt_h, Atm(child_grid_num)%neststruct%ind_h, &
+          delta_i_c, delta_j_c, x_refine, y_refine, is_fine_pe, nest_domain, position)
+      call mn_var_shift_data(mn_phys%hice, interp_type, wt_h, Atm(child_grid_num)%neststruct%ind_h, &
+          delta_i_c, delta_j_c, x_refine, y_refine, is_fine_pe, nest_domain, position)
 
     endif
 

--- a/fv3/moving_nest/fv_moving_nest_physics.F90
+++ b/fv3/moving_nest/fv_moving_nest_physics.F90
@@ -154,7 +154,6 @@ contains
 
     !print '("[INFO] MASK ICE npe=",I0," parent_ls num_seaice=",I0)',this_pe, num_seaice
 
-
     num_seaice = 0
 
     do i = lbound(mn_static%fp_ls%ls_mask_grid,1), ubound(mn_static%fp_ls%ls_mask_grid,1)
@@ -204,9 +203,6 @@ contains
     !print '("[INFO] MASK END inside mn_phys_apply_coarse_seaice npe=",I0)', this_pe
 
   end subroutine mn_phys_apply_coarse_seaice
-
-
-
 
 
   subroutine mn_phys_set_slmsk(Atm, n, mn_static, ioffset, joffset, refine)

--- a/fv3/moving_nest/fv_moving_nest_physics.F90
+++ b/fv3/moving_nest/fv_moving_nest_physics.F90
@@ -206,7 +206,7 @@ contains
           GFS_Sfcprop%oceanfrac(im) = 1   ! Ocean -- TODO permit fractions
           GFS_Sfcprop%landfrac(im) = 0    ! Ocean -- TODO permit fractions
 
-          GFS_Sfcprop%stype(im) = 0
+          GFS_Sfcprop%stype(im) = 14 ! change from 0 to 14 to avoid index conflict with porosity
           GFS_Sfcprop%slmsk(im) = 0
         else
           GFS_Sfcprop%stype(im) = nint(mn_static%fp_ls%soil_type_grid(i_idx, j_idx))
@@ -529,10 +529,23 @@ contains
     integer :: is, ie, js, je
     integer :: this_pe
     integer :: nb, blen, i, j ,k, ix, nv, im
+    integer :: isnow                           !local for Noah MP
+    real(kind=kind_phys) :: dzs(1:4)           !local for Noah MP
+    real(kind=kind_phys) :: dzsno(-2:0)        !local for Noah MP
+    real(kind=kind_phys) :: dzsnso(-2:4)       !local for Noah MP
+    real(kind=kind_phys) :: porosity(1:19)     !local for Noah MP
+    real(kind=kind_phys) :: zsns_default(-2:4) !local for Noah MP
     type(fv_moving_nest_physics_type), pointer       :: mn_phys
 
     this_pe = mpp_pe()
     mn_phys => Moving_nest(n)%mn_phys
+    dzs      = (/0.1,0.3,0.6,1.0/)             ! 4 layer soil thickness
+    dzsno    = (/0.0,0.0,0.0/)                 ! 3 snow layer thichness
+    dzsnso   = (/0.0,0.0,0.0,0.1,0.3,0.6,1.0/) ! dzs + dzsno
+    porosity = (/0.339,0.421,0.434,0.476,0.484,0.439,0.404,0.464, &
+                 0.465,0.406,0.468,0.468,0.439,1.000,0.200,0.421, &
+                 0.468,0.200,0.339/)
+    zsns_default = (/0.0, 0.0, 0.0,  -0.1,-0.4,-1.0,-2.0 /) !depths from snow surface
 
     !  Needed to fill the local grids for parent and nest PEs in order to transmit/interpolate data from parent to nest
     !  But only the nest PE's have changed the values with nest motion, so they are the only ones that need to update the original arrays
@@ -706,7 +719,6 @@ contains
           if (GFS_control%lsm == GFS_control%lsm_noahmp) then
 
             GFS_sfcprop%scolor(im)  = mn_phys%soilcolor(i,j)
-            GFS_sfcprop%snowxy(im)     = mn_phys%snowxy(i,j)
             GFS_sfcprop%tvxy(im)       = mn_phys%tvxy(i,j)
             GFS_sfcprop%tgxy(im)       = mn_phys%tgxy(i,j)
             GFS_sfcprop%canicexy(im)   = mn_phys%canicexy(i,j)
@@ -735,45 +747,134 @@ contains
             GFS_sfcprop%smcwtdxy(im)   = mn_phys%smcwtdxy(i,j)
             GFS_sfcprop%deeprechxy(im) = mn_phys%deeprechxy(i,j)
             GFS_sfcprop%rechxy(im)     = mn_phys%rechxy(i,j)
-
-            do k = 1, GFS_control%lsoil
-               GFS_sfcprop%smoiseq(im,k)    = mn_phys%smoiseq(i,j,k)
-            enddo
-
-
-            do k = GFS_control%lsnow_lsm_lbound, GFS_control%lsnow_lsm_ubound
-              GFS_sfcprop%snicexy(im,k)    = mn_phys%snicexy(i,j,k)
-              GFS_sfcprop%snliqxy(im,k)    = mn_phys%snliqxy(i,j,k)
-              GFS_sfcprop%tsnoxy(im,k)     = mn_phys%tsnoxy(i,j,k)
-            enddo
-
             GFS_sfcprop%snowd(im)      = mn_phys%snowd(i,j)
             GFS_sfcprop%weasd(im)      = mn_phys%weasd(i,j)
 
-            do k = GFS_control%lsnow_lsm_lbound, GFS_control%lsoil
-              GFS_sfcprop%zsnsoxy(im,k)    = mn_phys%zsnsoxy(i,j,k)
+            if (GFS_sfcprop%snowd(im) == 0.0 .and. GFS_sfcprop%weasd(im) /= 0.0) then
+              GFS_sfcprop%snowd(im) = GFS_sfcprop%weasd(im)/10.0
+            endif
+
+            do k = 1, GFS_control%lsoil
+              GFS_sfcprop%smoiseq(im,k) = mn_phys%smoiseq(i,j,k)
             enddo
 
+            do k = 1, GFS_control%lsoil
+              GFS_sfcprop%smc(im,k) = min(GFS_sfcprop%smc(im,k),porosity(GFS_sfcprop%stype(im))-0.01)
+              GFS_sfcprop%slc(im,k) = min(GFS_sfcprop%slc(im,k),porosity(GFS_sfcprop%stype(im))-0.01)
+            enddo
+
+            if (GFS_sfcprop%vtype(im) == 15) then ! glacier
+              do k = 1,GFS_control%lsoil
+                GFS_sfcprop%stc(im,k) = min(mn_phys%stc(i,j,k), min(GFS_Sfcprop%tg3(im), 263.15))
+                GFS_sfcprop%smc(im,k) = 1.0
+                GFS_sfcprop%slc(im,k) = 0.0
+              enddo
+              GFS_sfcprop%weasd(im) = 600.0   ! 600mm SWE for glacier
+              GFS_sfcprop%snowd(im) = 2000.0  ! 2m snow depth for glacier, snowd/snwdph is in mm
+            endif
+
+            if (mn_phys%leading_edge(i,j) == .True. .and. GFS_sfcprop%snowd(im) < 99999.0) then ! new land with snow
+              if (GFS_sfcprop%snowd(im)/1000.0 < 0.025) then
+                GFS_sfcprop%snowxy(im) = 0.0
+                dzsno(-2:0) = 0.0
+              elseif (GFS_sfcprop%snowd(im)/1000.0 >= 0.025 .and. GFS_sfcprop%snowd(im)/1000.0 <= 0.05) then
+                GFS_sfcprop%snowxy(im) = -1.0
+                dzsno(0) = GFS_sfcprop%snowd(im)/1000.0
+              elseif (GFS_sfcprop%snowd(im)/1000.0 > 0.05 .and. GFS_sfcprop%snowd(im)/1000.0 <= 0.10) then
+                GFS_sfcprop%snowxy(im) = -2.0
+                dzsno(-1) = 0.5*GFS_sfcprop%snowd(im)/1000.0
+                dzsno(0) = 0.5*GFS_sfcprop%snowd(im)/1000.0
+              elseif (GFS_sfcprop%snowd(im)/1000.0> 0.10 .and. GFS_sfcprop%snowd(im)/1000.0 <= 0.25) then
+                GFS_sfcprop%snowxy(im) = -2.0
+                dzsno(-1) = 0.05
+                dzsno(0) = GFS_sfcprop%snowd(im)/1000.0 - 0.05
+              elseif (GFS_sfcprop%snowd(im)/1000.0 > 0.25 .and. GFS_sfcprop%snowd(im)/1000.0 <= 0.45) then
+                GFS_sfcprop%snowxy(im) = -3.0
+                dzsno(-2) = 0.05
+                dzsno(-1) = 0.5*(GFS_sfcprop%snowd(im)/1000.0-0.05)
+                dzsno(0) = 0.5*(GFS_sfcprop%snowd(im)/1000.0-0.05)
+              elseif (GFS_sfcprop%snowd(im)/1000.0 > 0.45) then
+                GFS_sfcprop%snowxy(im) = -3.0
+                dzsno(-2) = 0.05
+                dzsno(-1) = 0.20
+                dzsno(0) = GFS_sfcprop%snowd(im)/1000.0 - 0.05 - 0.20
+              else
+                write(*,*)  'Error in fv_moving_nest_physics.F90 - Problem with the logic assigning snow layers'
+                stop
+              endif
+              isnow = nint(GFS_sfcprop%snowxy(im)) + 1
+              do k = isnow, GFS_control%lsnow_lsm_ubound
+                GFS_sfcprop%tsnoxy(im,k) = GFS_sfcprop%tgxy(im) + ( (sum(dzsno(isnow:k))-0.5*dzsno(k)) / \
+                                           GFS_sfcprop%snowd(im)/1000.0 ) * (GFS_sfcprop%stc(im,1)-GFS_sfcprop%tgxy(im))
+                GFS_sfcprop%snliqxy(im,k) = 0.0
+                GFS_sfcprop%snicexy(im,k) = 1.0 * dzsno(k) * GFS_sfcprop%weasd(im)/GFS_sfcprop%snowd(im)
+              enddo
+              do k = isnow,GFS_control%lsnow_lsm_ubound
+                dzsnso(k) = -dzsno(k)
+              enddo
+              do k = 1, GFS_control%lsoil
+                dzsnso(k) = -dzs(k)
+              enddo
+              GFS_sfcprop%zsnsoxy(im,isnow) = dzsnso(isnow)
+
+              do k = isnow + 1, GFS_control%lsoil
+                GFS_sfcprop%zsnsoxy(im, k) = GFS_sfcprop%zsnsoxy(im,k-1) + dzsnso(k)
+              enddo
+            else ! internal moving land points
+              GFS_sfcprop%snowxy(im) = mn_phys%snowxy(i,j)
+              isnow = nint(GFS_sfcprop%snowxy(im)) + 1
+              if (abs(isnow) < GFS_control%lsoil) then ! only isnow /= fill value
+                do k = GFS_control%lsnow_lsm_lbound, GFS_control%lsnow_lsm_ubound
+                  GFS_sfcprop%snicexy(im,k) = mn_phys%snicexy(i,j,k)
+                  GFS_sfcprop%snliqxy(im,k) = mn_phys%snliqxy(i,j,k)
+                  GFS_sfcprop%tsnoxy(im,k)  = mn_phys%tsnoxy(i,j,k)
+                enddo
+                do k = isnow, GFS_control%lsoil
+                  GFS_sfcprop%zsnsoxy(im,k) = mn_phys%zsnsoxy(i,j,k)
+                enddo
+              endif
+              ! reset snow-related fields over the old glacier points to be consistent with the new glacier land points
+              ! for the next iteration
+              if (GFS_sfcprop%vtype(im) == 15) then
+                GFS_sfcprop%snowxy(im) = -3.0
+                dzsno(-2) = 0.05
+                dzsno(-1) = 0.20
+                dzsno(0) = 2.0 - 0.05 - 0.20
+                isnow = -2
+                do k = isnow, GFS_control%lsnow_lsm_ubound
+                  GFS_sfcprop%tsnoxy(im,k) = GFS_sfcprop%tgxy(im) + ( (sum(dzsno(isnow:k))-0.5*dzsno(k)) / \
+                                             GFS_sfcprop%snowd(im)/1000.0 ) * (GFS_sfcprop%stc(im,1)-GFS_sfcprop%tgxy(im))
+                  GFS_sfcprop%snliqxy(im,k) = 0.0
+                  GFS_sfcprop%snicexy(im,k) = 1.0 * dzsno(k) * GFS_sfcprop%weasd(im)/GFS_sfcprop%snowd(im)
+                enddo
+                do k = isnow, GFS_control%lsnow_lsm_ubound
+                  dzsnso(k) = -dzsno(k)
+                enddo
+                do k = 1, GFS_control%lsoil
+                  dzsnso(k) = -dzs(k)
+                enddo
+                GFS_sfcprop%zsnsoxy(im,isnow) = dzsnso(isnow)
+                do k = isnow + 1, GFS_control%lsoil
+                  GFS_sfcprop%zsnsoxy(im, k) = GFS_sfcprop%zsnsoxy(im,k-1) + dzsnso(k)
+                enddo
+              endif
+            endif
           endif
 
-          ! Check if stype and vtype are properly set for land points.  Set to reasonable values if they have fill values.
-          if ( (int(GFS_sfcprop%slmsk(im)) .eq. 1) )  then
-
+          ! Check if stype and vtype are properly set for land points. Set to reasonable values if they have fill values.
+          if ( (int(GFS_sfcprop%slmsk(im)) .eq. 1) ) then
             if (GFS_sfcprop%vtype(im) .lt. 0.5) then
               GFS_sfcprop%vtype(im) = 7    ! Force to grassland
             endif
-
             if (GFS_sfcprop%stype(im) .lt. 0.5) then
               GFS_sfcprop%stype(im) = 3    ! Force to sandy loam
             endif
-
             if (GFS_sfcprop%vtype_save(im) .lt. 0.5) then
               GFS_sfcprop%vtype_save(im) = 7    ! Force to grassland
             endif
             if (GFS_sfcprop%stype_save(im) .lt. 0.5) then
               GFS_sfcprop%stype_save(im) = 3    ! Force to sandy loam
             endif
-
           endif
         enddo
       enddo
@@ -1278,7 +1379,7 @@ contains
           is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0)
 
       call fill_nest_halos_from_parent_masked("smoiseq", mn_phys%smoiseq, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
-          Atm(child_grid_num)%neststruct%ind_h, & 
+          Atm(child_grid_num)%neststruct%ind_h, &
           x_refine, y_refine, &
           is_fine_pe, nest_domain, position, 1, GFS_control%lsoil, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.3D0)
 

--- a/fv3/moving_nest/fv_moving_nest_types.F90
+++ b/fv3/moving_nest/fv_moving_nest_types.F90
@@ -80,7 +80,7 @@ module fv_moving_nest_types_mod
   type mn_land_mask_grids
     real, allocatable  :: orog_grid(:,:)               _NULL  ! orography -- raw or filtered depending on namelist option, in meters
     real, allocatable  :: orog_std_grid(:,:)           _NULL  ! terrain standard deviation for gravity wave drag, in meters (?)
-    real, allocatable  :: ls_mask_grid(:,:)            _NULL  ! land sea mask -- 0 for ocean/lakes, 1, for land.  Perhaps 2 for sea ice.
+    real, allocatable  :: ls_mask_grid(:,:)            _NULL  ! land sea mask -- 0 for ocean/lakes, 1, for land.  2 for sea ice.
     real, allocatable  :: soil_type_grid(:,:)          _NULL  ! STATSGO soil type
     ! Land frac needs to be kind_phys because CCPP defines it that way.  Can have rounding mismatches around 0.5 if types don't match.
     real(kind=kind_phys), allocatable  :: land_frac_grid(:,:)          _NULL  ! Continuous land fraction - 0.0 ocean, 0.5 half of each, 1.0 all land
@@ -272,6 +272,15 @@ module fv_moving_nest_types_mod
     real (kind=kind_phys), _ALLOCATABLE :: weasd (:,:)      _NULL   !< water equivalent accumulated snow depth over land
     real (kind=kind_phys), _ALLOCATABLE :: zsnsoxy (:,:,:)  _NULL   !< depth from snow surface at bottom interface
 
+    ! ICEFIX Additional cryosphere variables Sept 2025
+    real (kind=kind_phys), _ALLOCATABLE :: tiice (:,:,:)    _NULL   !< sea ice internal temperature, 2 layers [K]
+    real (kind=kind_phys), _ALLOCATABLE :: tisfc (:,:)      _NULL   !< surface skin temperature over ice [K]
+    real (kind=kind_phys), _ALLOCATABLE :: sncovr (:,:)     _NULL   !< snow cover in fraction over land
+
+    real (kind=kind_phys), _ALLOCATABLE :: fice (:,:)       _NULL   !< sea ice fraction
+    real (kind=kind_phys), _ALLOCATABLE :: hice (:,:)       _NULL   !< sea ice thickness
+
+    
   end type fv_moving_nest_physics_type
 
   type fv_moving_nest_type
@@ -326,7 +335,7 @@ contains
 
     mn_phys%leading_edge(isd:isd+2,:) = .True.
     mn_phys%leading_edge(ied-2:ied,:) = .True.
-
+    
     mn_phys%leading_edge(:, jsd:jsd+2) = .True.
     mn_phys%leading_edge(:, jed-2:jed) = .True.
 
@@ -344,9 +353,8 @@ contains
       mn_phys%leading_edge(:, jed-5:jed-3) = .True.
     endif
 
+
   end subroutine mn_set_leading_edge
-
-
   
   subroutine fv_moving_nest_init(Atm, this_grid)
     type(fv_atmos_type), allocatable, intent(in) :: Atm(:)
@@ -752,6 +760,14 @@ contains
       allocate ( mn_phys%weasd(isd:ied, jsd:jed) )
       allocate ( mn_phys%zsnsoxy(isd:ied, jsd:jed, lsnow_lbound:lsoil) )
 
+      ! ICEFIX
+      allocate ( mn_phys%tiice(isd:ied, jsd:jed, 2) )
+      allocate ( mn_phys%tisfc(isd:ied, jsd:jed) )
+      allocate ( mn_phys%sncovr(isd:ied, jsd:jed) )
+      allocate ( mn_phys%fice(isd:ied, jsd:jed) )
+      allocate ( mn_phys%hice(isd:ied, jsd:jed) )
+
+      
       !allocate ( mn_phys%ustar1(isd:ied, jsd:jed) )
     endif
 
@@ -884,6 +900,13 @@ contains
       mn_phys%tsnoxy = +99999.9
       mn_phys%weasd = +99999.9
       mn_phys%zsnsoxy = +99999.9
+
+      mn_phys%tiice = +99999.9
+      mn_phys%tisfc = +99999.9
+      mn_phys%sncovr = +99999.9
+
+      mn_phys%fice = +99999.9
+      mn_phys%hice = +99999.9
 
       !mn_phys%ustar1 = +99999.9
     endif
@@ -1029,6 +1052,12 @@ contains
       deallocate ( mn_phys%tsnoxy )
       deallocate ( mn_phys%weasd )
       deallocate ( mn_phys%zsnsoxy )
+
+      deallocate ( mn_phys%tiice )
+      deallocate ( mn_phys%tisfc )
+      deallocate ( mn_phys%sncovr )
+      deallocate ( mn_phys%fice )
+      deallocate ( mn_phys%hice )
 
     endif
 

--- a/fv3/moving_nest/fv_moving_nest_types.F90
+++ b/fv3/moving_nest/fv_moving_nest_types.F90
@@ -144,6 +144,9 @@ module fv_moving_nest_types_mod
   type fv_moving_nest_physics_type
     real, _ALLOCATABLE                  :: ts(:,:)          _NULL   !< 2D skin temperature/SST
     real, _ALLOCATABLE                  :: slmsk(:,:)       _NULL   !< land sea mask -- 0 for ocean/lakes, 1, for land.  Perhaps 2 for sea ice.
+
+    logical, _ALLOCATABLE               :: leading_edge(:,:) _NULL  !< logical array -- at each nest move timestep, is this point getting interpolated values at the leading edge
+
     real (kind=kind_phys), _ALLOCATABLE :: smc (:,:,:)      _NULL   !< soil moisture content
     real (kind=kind_phys), _ALLOCATABLE :: stc (:,:,:)      _NULL   !< soil temperature
     real (kind=kind_phys), _ALLOCATABLE :: slc (:,:,:)      _NULL   !< soil liquid water content
@@ -314,6 +317,37 @@ module fv_moving_nest_types_mod
 
 contains
 
+  subroutine mn_set_leading_edge(mn_phys, isd, ied, jsd, jed, ioffset, joffset)
+    type(fv_moving_nest_physics_type), intent(inout) :: mn_phys
+    integer, intent(in)                              :: isd, ied, jsd, jed
+    integer, intent(in)                              :: ioffset, joffset
+
+    mn_phys%leading_edge = .False.
+
+    mn_phys%leading_edge(isd:isd+2,:) = .True.
+    mn_phys%leading_edge(ied-2:ied,:) = .True.
+
+    mn_phys%leading_edge(:, jsd:jsd+2) = .True.
+    mn_phys%leading_edge(:, jed-2:jed) = .True.
+
+    if (ioffset .eq. 1) then
+      mn_phys%leading_edge(isd+3:isd+5, :) = .True.
+    endif
+    if (ioffset .eq. -1) then
+      mn_phys%leading_edge(ied-5:isd-3, :) = .True.
+    endif
+
+    if (joffset .eq. 1) then
+      mn_phys%leading_edge(: ,jsd+3:jsd+5) = .True.
+    endif
+    if (joffset .eq. -1) then
+      mn_phys%leading_edge(:, jed-5:jsd-3) = .True.
+    endif
+
+  end subroutine mn_set_leading_edge
+
+
+  
   subroutine fv_moving_nest_init(Atm, this_grid)
     type(fv_atmos_type), allocatable, intent(in) :: Atm(:)
     integer, intent(in)                          :: this_grid
@@ -592,6 +626,8 @@ contains
     !print '("[INFO] WDR allocate_fv_moving_nest_physics_type npe=",I0," lsnow_lbound=",I0," lsnow_ubound=",I0," lsoil=",I0)', mpp_pe(), lsnow_lbound, lsnow_ubound, lsoil
 
     if (move_physics) then
+      allocate ( mn_phys%leading_edge (isd:ied, jsd:jed) )
+
       allocate ( mn_phys%slmsk(isd:ied, jsd:jed) )
       allocate ( mn_phys%smc(isd:ied, jsd:jed, lsoil) )
       allocate ( mn_phys%stc(isd:ied, jsd:jed, lsoil) )
@@ -721,6 +757,8 @@ contains
 
     mn_phys%ts = +99999.9
     if (move_physics) then
+      mn_phys%leading_edge = .false.
+
       mn_phys%slmsk = +99999.9
       mn_phys%smc = +99999.9
       mn_phys%stc = +99999.9
@@ -865,6 +903,7 @@ contains
 
     !  if move_phys
     if (allocated(mn_phys%smc)) then
+      deallocate( mn_phys%leading_edge )
       deallocate( mn_phys%slmsk )
       deallocate( mn_phys%smc )
       deallocate( mn_phys%stc )

--- a/fv3/moving_nest/fv_moving_nest_types.F90
+++ b/fv3/moving_nest/fv_moving_nest_types.F90
@@ -334,14 +334,14 @@ contains
       mn_phys%leading_edge(isd+3:isd+5, :) = .True.
     endif
     if (ioffset .eq. -1) then
-      mn_phys%leading_edge(ied-5:isd-3, :) = .True.
+      mn_phys%leading_edge(ied-5:ied-3, :) = .True.
     endif
 
     if (joffset .eq. 1) then
       mn_phys%leading_edge(: ,jsd+3:jsd+5) = .True.
     endif
     if (joffset .eq. -1) then
-      mn_phys%leading_edge(:, jed-5:jsd-3) = .True.
+      mn_phys%leading_edge(:, jed-5:jed-3) = .True.
     endif
 
   end subroutine mn_set_leading_edge

--- a/fv3/moving_nest/fv_moving_nest_types.F90
+++ b/fv3/moving_nest/fv_moving_nest_types.F90
@@ -766,7 +766,6 @@ contains
       allocate ( mn_phys%sncovr(isd:ied, jsd:jed) )
       allocate ( mn_phys%fice(isd:ied, jsd:jed) )
       allocate ( mn_phys%hice(isd:ied, jsd:jed) )
-
       
       !allocate ( mn_phys%ustar1(isd:ied, jsd:jed) )
     endif


### PR DESCRIPTION
## Description
The following changes are from @RongqianYang-NOAA, @barlage, and @wramstrom, to address NoahMP LSM and sea-ice related moving-nesting issues.
  - Add snow layer and snow soil layer thickness to GFS_type.
  - Add checks for soil moisture for Noah MP.
  - Changes for distinguishing between new and old points for snow-related fields reset in moving nest physics.
  - Add leading_edge logical array to indicate which nest points have been interpolated. Needed for NOAH MP moving nest upgrades.
  - NOAHMP moving nest sea ice and cryosphere fixes and added variables tiice, tisfc, sncovr, fice, hice.