### PR TITLE
NoahMP LSM and moving nesting related changes/fixes

### DIFF
--- a/fv3/moving_nest/fv_moving_nest.F90
+++ b/fv3/moving_nest/fv_moving_nest.F90
@@ -907,7 +907,8 @@ contains
 
     call mn_static_read_hires(npx, npy, refine, pelist, trim(surface_dir), "substrate_temperature", "substrate_temperature", static_fix%deep_soil_temp_grid, tile_num)
     ! set any -999s to +4C
-    call mn_replace_low_values(static_fix%deep_soil_temp_grid, -100.0, 277.0)
+    !call mn_replace_low_values(static_fix%deep_soil_temp_grid, -100.0, 277.0)
+    call mn_replace_low_values(static_fix%deep_soil_temp_grid, -100.0, -1.e20)
 
     !! TODO investigate reading high-resolution veg_frac and veg_greenness
     !call mn_static_read_hires(npx, npy, refine, trim(Moving_nest(child_grid_num)%mn_flag%surface_dir), "", mn_static%veg_frac_grid)

--- a/fv3/moving_nest/fv_moving_nest_physics.F90
+++ b/fv3/moving_nest/fv_moving_nest_physics.F90
@@ -284,13 +284,15 @@ contains
           if (move_nsst) GFS_Sfcprop%ifd(im) = 0         ! Land
           GFS_Sfcprop%oceanfrac(im) = 0   ! Land -- TODO permit fractions
           GFS_Sfcprop%landfrac(im) = 1    ! Land -- TODO permit fractions
-          GFS_Sfcprop%fice(im) = 0        ! ice fraction over open water grid
+          GFS_Sfcprop%fice(im) = 0
+          GFS_Sfcprop%hice(im) = 0
         !else if (mn_static%fp_ls%ls_mask_grid(i_idx, j_idx) .eq. M_WATER ) then   ! Ocean
         else if (cell_slmsk .eq. M_WATER ) then   ! Ocean
           if (move_nsst) GFS_Sfcprop%ifd(im) = 1         ! Ocean
           GFS_Sfcprop%oceanfrac(im) = 1   ! Ocean -- TODO permit fractions
           GFS_Sfcprop%landfrac(im) = 0    ! Ocean -- TODO permit fractions
-          GFS_Sfcprop%fice(im) = 0        ! ice fraction over open water grid
+          GFS_Sfcprop%fice(im) = 0
+          GFS_Sfcprop%hice(im) = 0
         !else if (mn_static%fp_ls%ls_mask_grid(i_idx, j_idx) .eq. M_SEAICE ) then     ! Sea Ice
         else if (cell_slmsk .eq. M_SEAICE ) then     ! Sea Ice
           if (move_nsst) GFS_Sfcprop%ifd(im) = 0         ! For Sea ice - ifd is set to Land 0, checked in sfc files
@@ -651,7 +653,7 @@ contains
     real(kind=kind_phys) :: dzs(1:4)           !local for Noah MP
     real(kind=kind_phys) :: dzsno(-2:0)        !local for Noah MP
     real(kind=kind_phys) :: dzsnso(-2:4)       !local for Noah MP
-    real(kind=kind_phys) :: porosity(1:19)     !local for Noah MP
+    real(kind=kind_phys) :: porosity(0:19)     !local for Noah MP, add fake porosity for stype 0
     real(kind=kind_phys) :: zsns_default(-2:4) !local for Noah MP
     type(fv_moving_nest_physics_type), pointer       :: mn_phys
 
@@ -660,7 +662,7 @@ contains
     dzs      = (/0.1,0.3,0.6,1.0/)             ! 4 layer soil thickness
     dzsno    = (/0.0,0.0,0.0/)                 ! 3 snow layer thichness
     dzsnso   = (/0.0,0.0,0.0,0.1,0.3,0.6,1.0/) ! dzs + dzsno
-    porosity = (/0.339,0.421,0.434,0.476,0.484,0.439,0.404,0.464, &
+    porosity = (/1.000,0.339,0.421,0.434,0.476,0.484,0.439,0.404,0.464, &
                  0.465,0.406,0.468,0.468,0.439,1.000,0.200,0.421, &
                  0.468,0.200,0.339/)
     zsns_default = (/0.0, 0.0, 0.0,  -0.1,-0.4,-1.0,-2.0 /) !depths from snow surface
@@ -882,12 +884,20 @@ contains
             GFS_sfcprop%tisfc(im) = mn_phys%tisfc(i,j)
             GFS_sfcprop%sncovr(im) = mn_phys%sncovr(i,j)
 
-            GFS_sfcprop%fice(im) = mn_phys%fice(i,j)
-            GFS_sfcprop%hice(im) = mn_phys%hice(i,j)
+            if ( (nint(GFS_sfcprop%slmsk(im)) .eq. 2) ) then
+              GFS_sfcprop%fice(im) = mn_phys%fice(i,j)
+              GFS_sfcprop%hice(im) = mn_phys%hice(i,j)
+            else
+              GFS_sfcprop%fice(im) = 0.
+              GFS_sfcprop%hice(im) = 0.
+            endif
 
             do k = 1, GFS_control%lsoil
               GFS_sfcprop%smoiseq(im,k) = mn_phys%smoiseq(i,j,k)
             enddo
+
+            ! Reset over land only
+            if (nint(GFS_sfcprop%slmsk(im)) .eq. 1) then
 
             do k = 1, GFS_control%lsoil
               GFS_sfcprop%smc(im,k) = min(GFS_sfcprop%smc(im,k),porosity(GFS_sfcprop%stype(im))-0.01)
@@ -990,10 +1000,12 @@ contains
                 enddo
               endif
             endif
+
+            endif ! Reset over land only
           endif
 
           ! Check if stype and vtype are properly set for land points. Set to reasonable values if they have fill values.
-          if ( (int(GFS_sfcprop%slmsk(im)) .eq. 1) ) then
+          if ( (nint(GFS_sfcprop%slmsk(im)) .eq. 1) ) then
             if (GFS_sfcprop%vtype(im) .lt. 0.5) then
               GFS_sfcprop%vtype(im) = 7    ! Force to grassland
             endif
@@ -1526,10 +1538,10 @@ contains
 
       call fill_nest_halos_from_parent_masked("fice", mn_phys%fice, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_SEAICE, 1.0D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_SEAICE, 0.0D0)
       call fill_nest_halos_from_parent_masked("hice", mn_phys%hice, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_SEAICE, 0.1D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_SEAICE, 0.0D0)
 
     endif
 

--- a/fv3/moving_nest/fv_moving_nest_physics.F90
+++ b/fv3/moving_nest/fv_moving_nest_physics.F90
@@ -885,12 +885,21 @@ contains
 
             ! Vegetation variables: perform some bounds checks in case nest vegetated grids inherit from non-veg parent
 
-            GFS_sfcprop%tvxy(im)       = min(max(mn_phys%tvxy(i,j) ,mn_phys%tsfc(i,j)-5.0),mn_phys%tsfc(i,j)+5.0)
-            GFS_sfcprop%tahxy(im)      = min(max(mn_phys%tahxy(i,j),mn_phys%tsfc(i,j)-5.0),mn_phys%tsfc(i,j)+5.0)
-            GFS_sfcprop%fwetxy(im)     = min(max(mn_phys%fwetxy(i,j),0.0),1.0)
-            GFS_sfcprop%canicexy(im)   = min(max(mn_phys%canicexy(i,j),0.0),100.0)
-            GFS_sfcprop%canliqxy(im)   = min(max(mn_phys%canliqxy(i,j),0.0),100.0)
-            GFS_sfcprop%eahxy(im)      = min(max(mn_phys%eahxy(i,j),500.0),4000.0)
+            if (mn_phys%leading_edge(i,j) ) then
+              GFS_sfcprop%tvxy(im)     = min(max(mn_phys%tvxy(i,j) ,mn_phys%tsfc(i,j)-5.0),mn_phys%tsfc(i,j)+5.0)
+              GFS_sfcprop%tahxy(im)    = min(max(mn_phys%tahxy(i,j),mn_phys%tsfc(i,j)-5.0),mn_phys%tsfc(i,j)+5.0)
+              GFS_sfcprop%fwetxy(im)   = min(max(mn_phys%fwetxy(i,j),0.0),1.0)
+              GFS_sfcprop%canicexy(im) = min(max(mn_phys%canicexy(i,j),0.0),100.0)
+              GFS_sfcprop%canliqxy(im) = min(max(mn_phys%canliqxy(i,j),0.0),100.0)
+              GFS_sfcprop%eahxy(im)    = min(max(mn_phys%eahxy(i,j),500.0),4000.0)
+            else
+              GFS_sfcprop%tvxy(im)     = mn_phys%tvxy(i,j)
+              GFS_sfcprop%tahxy(im)    = mn_phys%tahxy(i,j)
+              GFS_sfcprop%fwetxy(im)   = mn_phys%fwetxy(i,j)
+              GFS_sfcprop%canicexy(im) = mn_phys%canicexy(i,j)
+              GFS_sfcprop%canliqxy(im) = mn_phys%canliqxy(i,j)
+              GFS_sfcprop%eahxy(im)    = mn_phys%eahxy(i,j)
+            endif
 
             if (GFS_sfcprop%snowd(im) == 0.0 .and. GFS_sfcprop%weasd(im) /= 0.0) then
               GFS_sfcprop%snowd(im) = GFS_sfcprop%weasd(im)/10.0

--- a/fv3/moving_nest/fv_moving_nest_physics.F90
+++ b/fv3/moving_nest/fv_moving_nest_physics.F90
@@ -857,15 +857,9 @@ contains
           if (GFS_control%lsm == GFS_control%lsm_noahmp) then
 
             GFS_sfcprop%scolor(im)     = mn_phys%soilcolor(i,j)
-            GFS_sfcprop%tvxy(im)       = mn_phys%tvxy(i,j)
             GFS_sfcprop%tgxy(im)       = mn_phys%tgxy(i,j)
-            GFS_sfcprop%canicexy(im)   = mn_phys%canicexy(i,j)
-            GFS_sfcprop%canliqxy(im)   = mn_phys%canliqxy(i,j)
-            GFS_sfcprop%eahxy(im)      = mn_phys%eahxy(i,j)
-            GFS_sfcprop%tahxy(im)      = mn_phys%tahxy(i,j)
             GFS_sfcprop%cmxy(im)       = mn_phys%cmxy(i,j)
             GFS_sfcprop%chxy(im)       = mn_phys%chxy(i,j)
-            GFS_sfcprop%fwetxy(im)     = mn_phys%fwetxy(i,j)
             GFS_sfcprop%sneqvoxy(im)   = mn_phys%sneqvoxy(i,j)
             GFS_sfcprop%alboldxy(im)   = mn_phys%alboldxy(i,j)
             GFS_sfcprop%qsnowxy(im)    = mn_phys%qsnowxy(i,j)
@@ -888,6 +882,15 @@ contains
             GFS_sfcprop%snowd(im)      = mn_phys%snowd(i,j)
             GFS_sfcprop%weasd(im)      = mn_phys%weasd(i,j)
             GFS_sfcprop%sncovr(im)     = mn_phys%sncovr(i,j)
+
+            ! Vegetation variables: perform some bounds checks in case nest vegetated grids inherit from non-veg parent
+
+            GFS_sfcprop%tvxy(im)       = min(max(mn_phys%tvxy(i,j) ,mn_phys%tsfc(i,j)-5.0),mn_phys%tsfc(i,j)+5.0)
+            GFS_sfcprop%tahxy(im)      = min(max(mn_phys%tahxy(i,j),mn_phys%tsfc(i,j)-5.0),mn_phys%tsfc(i,j)+5.0)
+            GFS_sfcprop%fwetxy(im)     = min(max(mn_phys%fwetxy(i,j),0.0),1.0)
+            GFS_sfcprop%canicexy(im)   = min(max(mn_phys%canicexy(i,j),0.0),100.0)
+            GFS_sfcprop%canliqxy(im)   = min(max(mn_phys%canliqxy(i,j),0.0),100.0)
+            GFS_sfcprop%eahxy(im)      = min(max(mn_phys%eahxy(i,j),500.0),4000.0)
 
             if (GFS_sfcprop%snowd(im) == 0.0 .and. GFS_sfcprop%weasd(im) /= 0.0) then
               GFS_sfcprop%snowd(im) = GFS_sfcprop%weasd(im)/10.0

--- a/fv3/moving_nest/fv_moving_nest_physics.F90
+++ b/fv3/moving_nest/fv_moving_nest_physics.F90
@@ -800,6 +800,15 @@ contains
               GFS_sfcprop%albdifnir_lnd (im)   = 0.5
             endif
 
+            ! ICEFIX handle tiice
+            do k = 1, GFS_control%kice
+              GFS_sfcprop%tiice(im,k) = mn_phys%tiice(i,j,k)
+            enddo
+            if (mn_phys%tisfc(i,j) .lt. 240.0 .or. mn_phys%tisfc(i,j) .gt. 285.0 ) then
+              mn_phys%tisfc(i,j) = 273.15 - 5.0
+            endif
+            GFS_sfcprop%tisfc(im) = mn_phys%tisfc(i,j)
+
             ! Sea-ice related variables
             if ( (nint(GFS_sfcprop%slmsk(im)) .eq. 2) ) then
               GFS_sfcprop%fice(im) = mn_phys%fice(i,j)
@@ -847,7 +856,7 @@ contains
 
           if (GFS_control%lsm == GFS_control%lsm_noahmp) then
 
-            GFS_sfcprop%scolor(im)  = mn_phys%soilcolor(i,j)
+            GFS_sfcprop%scolor(im)     = mn_phys%soilcolor(i,j)
             GFS_sfcprop%tvxy(im)       = mn_phys%tvxy(i,j)
             GFS_sfcprop%tgxy(im)       = mn_phys%tgxy(i,j)
             GFS_sfcprop%canicexy(im)   = mn_phys%canicexy(i,j)
@@ -878,20 +887,11 @@ contains
             GFS_sfcprop%rechxy(im)     = mn_phys%rechxy(i,j)
             GFS_sfcprop%snowd(im)      = mn_phys%snowd(i,j)
             GFS_sfcprop%weasd(im)      = mn_phys%weasd(i,j)
+            GFS_sfcprop%sncovr(im)     = mn_phys%sncovr(i,j)
 
             if (GFS_sfcprop%snowd(im) == 0.0 .and. GFS_sfcprop%weasd(im) /= 0.0) then
               GFS_sfcprop%snowd(im) = GFS_sfcprop%weasd(im)/10.0
             endif
-
-            ! ICEFIX handle tiice
-            do k = 1, GFS_control%kice
-              GFS_sfcprop%tiice(im,k) = mn_phys%tiice(i,j,k)
-            enddo
-            if (mn_phys%tisfc(i,j) .lt. 240.0 .or. mn_phys%tisfc(i,j) .gt. 285.0 ) then
-              mn_phys%tisfc(i,j) = 273.15 - 5.0
-            endif
-            GFS_sfcprop%tisfc(im) = mn_phys%tisfc(i,j)
-            GFS_sfcprop%sncovr(im) = mn_phys%sncovr(i,j)
 
             do k = 1, GFS_control%lsoil
               GFS_sfcprop%smoiseq(im,k) = mn_phys%smoiseq(i,j,k)

--- a/fv3/moving_nest/fv_moving_nest_physics.F90
+++ b/fv3/moving_nest/fv_moving_nest_physics.F90
@@ -800,6 +800,15 @@ contains
               GFS_sfcprop%albdifnir_lnd (im)   = 0.5
             endif
 
+            ! Sea-ice related variables
+            if ( (nint(GFS_sfcprop%slmsk(im)) .eq. 2) ) then
+              GFS_sfcprop%fice(im) = mn_phys%fice(i,j)
+              GFS_sfcprop%hice(im) = mn_phys%hice(i,j)
+            else
+              GFS_sfcprop%fice(im) = 0.
+              GFS_sfcprop%hice(im) = 0.
+            endif
+
             ! Cloud properties
             GFS_cldprop%cv(im) = mn_phys%cv(i,j)
             GFS_cldprop%cvt(im) = mn_phys%cvt(i,j)
@@ -883,14 +892,6 @@ contains
             endif
             GFS_sfcprop%tisfc(im) = mn_phys%tisfc(i,j)
             GFS_sfcprop%sncovr(im) = mn_phys%sncovr(i,j)
-
-            if ( (nint(GFS_sfcprop%slmsk(im)) .eq. 2) ) then
-              GFS_sfcprop%fice(im) = mn_phys%fice(i,j)
-              GFS_sfcprop%hice(im) = mn_phys%hice(i,j)
-            else
-              GFS_sfcprop%fice(im) = 0.
-              GFS_sfcprop%hice(im) = 0.
-            endif
 
             do k = 1, GFS_control%lsoil
               GFS_sfcprop%smoiseq(im,k) = mn_phys%smoiseq(i,j,k)


### PR DESCRIPTION
This commits include some NoahMP LSM and moving nesting related changes/fixes. Based on discussions/tests mainly from: @ChuankaiWang-NOAA, @RongqianYang-NOAA, @barlage, @wramstrom, @BijuThomas-NOAA, @ZhanZhang-NOAA, @BinLiu-NOAA.
 - Define porosity with indexes from 0 to 19 and add an if condition to reset some variables only oever land points. (@RongqianYang-NOAA)
 - Properly set and reset default values for fice and hice variables. (@ChuankaiWang-NOAA, @barlage, @wramstrom, @BinLiu-NOAA)
 - Use a missing value for substrate_temperature/deep_soil_temp_grid, consistent with the tg3 missing value. (@ChuankaiWang-NOAA, @BinLiu-NOAA)
