### PR TITLE
Latest updates to address NoahMP LSM and moving nesting related issues

### DIFF
--- a/fv3/moving_nest/fv_moving_nest_physics.F90
+++ b/fv3/moving_nest/fv_moving_nest_physics.F90
@@ -104,9 +104,9 @@ module fv_moving_nest_physics_mod
   real, parameter:: real_snan=x'FFF7FFFFFFFFFFFF'
 #endif
 
-  real(kind=kind_phys) :: HUGE   = 9.9692099683868690E36  ! NetCDF float FillValue
-  real(kind=kind_phys) :: FN20   = -1.0E20                ! FillValue of -1.0E20
-  real(kind=kind_phys) :: FP20   = 9.99E20                ! FillValue of 9.99E20
+  real(kind=kind_phys), parameter :: HUGE   = 9.9692099683868690D36  ! NetCDF float FillValue
+  real(kind=kind_phys), parameter :: FN20  = -1.0D20                 ! FillValue of -1.0D20
+  real(kind=kind_phys), parameter :: FP20  = 9.99D20                 ! FillValue of 9.99D20
 
   logical :: debug_log = .false.
   logical :: move_physics = .true.       ! Always true, unless developer sets move_physics to .False. here for debugging.
@@ -708,7 +708,7 @@ contains
               enddo
             else
               GFS_sfcprop%smc(im,:) = 1.0
-              GFS_sfcprop%stc(im,:) = -1.0D20
+              GFS_sfcprop%stc(im,:) = FN20
               GFS_sfcprop%slc(im,:) = 1.0
             endif
 
@@ -907,10 +907,14 @@ contains
               GFS_sfcprop%tiice(im,:)    = 0.
             endif
 
-            if (mn_phys%tisfc(i,j) .lt. 240.0 .or. mn_phys%tisfc(i,j) .gt. 285.0 ) then
-              mn_phys%tisfc(i,j) = 273.15 - 5.0
+            if (nint(GFS_sfcprop%slmsk(im)) .eq. M_SEAICE) then
+              if (mn_phys%tisfc(i,j) .lt. 200.0 .or. mn_phys%tisfc(i,j) .gt. 285.0 ) then
+                mn_phys%tisfc(i,j) = 273.15 - 5.0
+              endif
+              GFS_sfcprop%tisfc(im) = mn_phys%tisfc(i,j)
+            else
+              GFS_sfcprop%tisfc(im) = mn_phys%tsfc(i,j)
             endif
-            GFS_sfcprop%tisfc(im) = mn_phys%tisfc(i,j)
 
             if (nint(GFS_sfcprop%slmsk(im)) .eq. M_SEAICE) then
               GFS_sfcprop%fice(im)       = mn_phys%fice(i,j)
@@ -920,8 +924,8 @@ contains
             else
               GFS_sfcprop%fice(im)       = 0.
               GFS_sfcprop%hice(im)       = 0.
-              GFS_sfcprop%snodi(im)      = -1.0D20
-              GFS_sfcprop%weasdi(im)     = -1.0D20
+              GFS_sfcprop%snodi(im)      = FN20
+              GFS_sfcprop%weasdi(im)     = FN20
             endif
 
             if (nint(GFS_sfcprop%slmsk(im)) .eq. M_LAND) then
@@ -1030,48 +1034,48 @@ contains
 
             else ! Reset variables for non land points
 
-            GFS_sfcprop%smoiseq(im,:)  = 9.99E+20
-            GFS_sfcprop%snicexy(im,:)  = 9.99E+20
-            GFS_sfcprop%snliqxy(im,:)  = 9.99E+20
-            GFS_sfcprop%tsnoxy(im,:)   = 9.99E+20
-            GFS_sfcprop%zsnsoxy(im,:)  = 9.99E+20
+            GFS_sfcprop%smoiseq(im,:)  = FP20
+            GFS_sfcprop%snicexy(im,:)  = FP20
+            GFS_sfcprop%snliqxy(im,:)  = FP20
+            GFS_sfcprop%tsnoxy(im,:)   = FP20
+            GFS_sfcprop%zsnsoxy(im,:)  = FP20
 
             GFS_sfcprop%scolor(im)     = 0        ! scolor is integer
-            GFS_sfcprop%tgxy(im)       = 9.99E+20
-            GFS_sfcprop%cmxy(im)       = 9.99E+20
-            GFS_sfcprop%chxy(im)       = 9.99E+20
-            GFS_sfcprop%sneqvoxy(im)   = 9.99E+20
-            GFS_sfcprop%alboldxy(im)   = 9.99E+20
-            GFS_sfcprop%qsnowxy(im)    = 9.99E+20
-            GFS_sfcprop%wslakexy(im)   = 9.99E+20
-            GFS_sfcprop%zwtxy(im)      = 9.99E+20
-            GFS_sfcprop%waxy(im)       = 9.99E+20
-            GFS_sfcprop%wtxy(im)       = 9.99E+20
-            GFS_sfcprop%lfmassxy(im)   = 9.99E+20
-            GFS_sfcprop%rtmassxy(im)   = 9.99E+20
-            GFS_sfcprop%stmassxy(im)   = 9.99E+20
-            GFS_sfcprop%woodxy(im)     = 9.99E+20
-            GFS_sfcprop%stblcpxy(im)   = 9.99E+20
-            GFS_sfcprop%fastcpxy(im)   = 9.99E+20
-            GFS_sfcprop%xsaixy(im)     = 9.99E+20
-            GFS_sfcprop%xlaixy(im)     = 9.99E+20
-            GFS_sfcprop%taussxy(im)    = 9.99E+20
-            GFS_sfcprop%smcwtdxy(im)   = 9.99E+20
-            GFS_sfcprop%deeprechxy(im) = 9.99E+20
-            GFS_sfcprop%rechxy(im)     = 9.99E+20
-            GFS_sfcprop%tvxy(im)       = 9.99E+20
-            GFS_sfcprop%tahxy(im)      = 9.99E+20
-            GFS_sfcprop%fwetxy(im)     = 9.99E+20
-            GFS_sfcprop%canicexy(im)   = 9.99E+20
-            GFS_sfcprop%canliqxy(im)   = 9.99E+20
-            GFS_sfcprop%eahxy(im)      = 9.99E+20
-            GFS_sfcprop%snowxy(im)     = 9.99E+20
+            GFS_sfcprop%tgxy(im)       = FP20
+            GFS_sfcprop%cmxy(im)       = FP20
+            GFS_sfcprop%chxy(im)       = FP20
+            GFS_sfcprop%sneqvoxy(im)   = FP20
+            GFS_sfcprop%alboldxy(im)   = FP20
+            GFS_sfcprop%qsnowxy(im)    = FP20
+            GFS_sfcprop%wslakexy(im)   = FP20
+            GFS_sfcprop%zwtxy(im)      = FP20
+            GFS_sfcprop%waxy(im)       = FP20
+            GFS_sfcprop%wtxy(im)       = FP20
+            GFS_sfcprop%lfmassxy(im)   = FP20
+            GFS_sfcprop%rtmassxy(im)   = FP20
+            GFS_sfcprop%stmassxy(im)   = FP20
+            GFS_sfcprop%woodxy(im)     = FP20
+            GFS_sfcprop%stblcpxy(im)   = FP20
+            GFS_sfcprop%fastcpxy(im)   = FP20
+            GFS_sfcprop%xsaixy(im)     = FP20
+            GFS_sfcprop%xlaixy(im)     = FP20
+            GFS_sfcprop%taussxy(im)    = FP20
+            GFS_sfcprop%smcwtdxy(im)   = FP20
+            GFS_sfcprop%deeprechxy(im) = FP20
+            GFS_sfcprop%rechxy(im)     = FP20
+            GFS_sfcprop%tvxy(im)       = FP20
+            GFS_sfcprop%tahxy(im)      = FP20
+            GFS_sfcprop%fwetxy(im)     = FP20
+            GFS_sfcprop%canicexy(im)   = FP20
+            GFS_sfcprop%canliqxy(im)   = FP20
+            GFS_sfcprop%eahxy(im)      = FP20
+            GFS_sfcprop%snowxy(im)     = FP20
             GFS_sfcprop%snowd(im)      = 0.
             GFS_sfcprop%weasd(im)      = 0.
             GFS_sfcprop%sncovr(im)     = 0.
 
-            GFS_sfcprop%snodl(im)      = -1.0D20
-            GFS_sfcprop%weasdl(im)     = -1.0D20
+            GFS_sfcprop%snodl(im)      = FN20
+            GFS_sfcprop%weasdl(im)     = FN20
 
             endif ! if (nint(GFS_sfcprop%slmsk(im)) .eq. M_LAND) then
 
@@ -1438,7 +1442,7 @@ contains
 
       call fill_nest_halos_from_parent_masked("snowxy", mn_phys%snowxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, FP20)
       call fill_nest_halos_from_parent_masked("tvxy", mn_phys%tvxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
           is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, mn_phys%tsfc, mn_phys%tsfc)
@@ -1448,14 +1452,14 @@ contains
 
       call fill_nest_halos_from_parent_masked("canicexy", mn_phys%canicexy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, FP20)
       call fill_nest_halos_from_parent_masked("canliqxy", mn_phys%canliqxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, FP20)
 
       call fill_nest_halos_from_parent_masked("eahxy", mn_phys%eahxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 2000.0D0, 9.99D20)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 2000.0D0, FP20)
 
       call fill_nest_halos_from_parent_masked("tahxy", mn_phys%tahxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
@@ -1464,115 +1468,115 @@ contains
       ! TODO get realistic default value here  -- bulk momentum drag coefficient
       call fill_nest_halos_from_parent_masked("cmxy", mn_phys%cmxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 2.4D-3, 9.99D20)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 2.4D-3, FP20)
 
       ! TODO get realistic default value here  -- bulk sensible heat drag coefficient
       call fill_nest_halos_from_parent_masked("chxy", mn_phys%chxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 2.4D-3, 9.99D20)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 2.4D-3, FP20)
 
       ! wetted or snowed fraction of the canopy
       call fill_nest_halos_from_parent_masked("fwetxy", mn_phys%fwetxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, FP20)
 
       ! snow mass at last time step[mm h2o]
       call fill_nest_halos_from_parent_masked("sneqvoxy", mn_phys%sneqvoxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, FP20)
 
       ! Albedo assuming deep snow on prev timestep - default to 0.65
       call fill_nest_halos_from_parent_masked("alboldxy", mn_phys%alboldxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.65D0, 9.99D20)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.65D0, FP20)
 
       ! Liquid equivalent snow - default to 0
       call fill_nest_halos_from_parent_masked("qsnowxy", mn_phys%qsnowxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, FP20)
 
       ! Lake water storage [mm] -- TODO find better default
       call fill_nest_halos_from_parent_masked("wslakexy", mn_phys%wslakexy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, FP20)
 
       ! Water table depth - set to 2.5, cold start value
       call fill_nest_halos_from_parent_masked("zwtxy", mn_phys%zwtxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 2.5D0, 9.99D20)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 2.5D0, FP20)
 
       ! Water storage in aquifer - set to 4900.0, cold start value
       call fill_nest_halos_from_parent_masked("waxy", mn_phys%waxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 4900.0D0, 9.99D20)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 4900.0D0, FP20)
       ! Water storage in aquifer and saturated soil - set to 4900.0, cold start value
       call fill_nest_halos_from_parent_masked("wtxy", mn_phys%wtxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 4900.0D0, 9.99D20)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 4900.0D0, FP20)
 
       ! Leaf mass [g/m2] -- TODO find better default
       call fill_nest_halos_from_parent_masked("lfmassxy", mn_phys%lfmassxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, FP20)
       ! Fine root mass [g/m2] -- TODO find better default
       call fill_nest_halos_from_parent_masked("rtmassxy", mn_phys%rtmassxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, FP20)
       ! Stem mass [g/m2] -- TODO find better default
       call fill_nest_halos_from_parent_masked("stmassxy", mn_phys%stmassxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, FP20)
       ! Wood mass [g/m2] -- TODO find better default
       call fill_nest_halos_from_parent_masked("woodxy", mn_phys%woodxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, FP20)
 
       ! stable carbon in deep soil [g/m2] -- TODO find a better default
       call fill_nest_halos_from_parent_masked("stblcpxy", mn_phys%stblcpxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, FP20)
       ! short-lived carbon, shallow soil [g/m2] -- TODO find a better default
       call fill_nest_halos_from_parent_masked("fastcpxy", mn_phys%fastcpxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, FP20)
 
       ! stem area index [m2/m2] -- TODO find a better default
       call fill_nest_halos_from_parent_masked("xsaixy", mn_phys%xsaixy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, FP20)
       ! leaf area index [m2/m2] -- TODO find a better default
       call fill_nest_halos_from_parent_masked("xlaixy", mn_phys%xlaixy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, FP20)
 
       ! snow age factor [-] -- TODO find a better default
       call fill_nest_halos_from_parent_masked("taussxy", mn_phys%taussxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, FP20)
 
       ! soil moisture content in the layer to the water table when deep -- TODO find a better default
       call fill_nest_halos_from_parent_masked("smcwtdxy", mn_phys%smcwtdxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, FP20)
 
       ! recharge to the water table when deep -- TODO find a better default
       call fill_nest_halos_from_parent_masked("deeprechxy", mn_phys%deeprechxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, FP20)
       ! recharge to the water table  -- TODO find a better default
       call fill_nest_halos_from_parent_masked("rechxy", mn_phys%rechxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, FP20)
 
       call fill_nest_halos_from_parent_masked("snicexy", mn_phys%snicexy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
           is_fine_pe, nest_domain, position, GFS_control%lsnow_lsm_lbound, GFS_control%lsnow_lsm_ubound, &
-          mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
+          mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, FP20)
 
       call fill_nest_halos_from_parent_masked("snliqxy", mn_phys%snliqxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
           is_fine_pe, nest_domain, position, GFS_control%lsnow_lsm_lbound,  GFS_control%lsnow_lsm_ubound, &
-          mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
+          mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, FP20)
 
       ! surface snow thickness water equivalent over land - - default to 0
       call fill_nest_halos_from_parent_masked("snowd", mn_phys%snowd, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
@@ -1584,7 +1588,7 @@ contains
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
           is_fine_pe, nest_domain, position, GFS_control%lsnow_lsm_lbound, GFS_control%lsnow_lsm_ubound, &
           !mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 273.15D0)
-          mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
+          mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, FP20)
 
       ! water equivalent accumulated snow depth over land - - default to 0
       call fill_nest_halos_from_parent_masked("weasd", mn_phys%weasd, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
@@ -1594,7 +1598,7 @@ contains
       call fill_nest_halos_from_parent_masked("smoiseq", mn_phys%smoiseq, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, &
           x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, 1, GFS_control%lsoil, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.3D0, 9.99D20)
+          is_fine_pe, nest_domain, position, 1, GFS_control%lsoil, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.3D0, FP20)
 
       call fill_nest_halos_from_parent_masked("zsnsoxy", mn_phys%zsnsoxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
@@ -1604,11 +1608,12 @@ contains
       ! ICEFIX tiice
       call fill_nest_halos_from_parent_masked("tiice", mn_phys%tiice, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, 1, 2, & !! kice
+          is_fine_pe, nest_domain, position, 1, GFS_control%kice, &
           mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_SEAICE, mn_phys%tsfc, mn_phys%tsfc)
       call fill_nest_halos_from_parent_masked("tisfc", mn_phys%tisfc, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
           is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_SEAICE, mn_phys%tsfc, mn_phys%tsfc)
+
       call fill_nest_halos_from_parent_masked("sncovr", mn_phys%sncovr, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
           is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 0.0D0)
@@ -1625,19 +1630,19 @@ contains
 
       call fill_nest_halos_from_parent_masked("snodl", mn_phys%snodl, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, -1.0D20)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, FN20)
 
       call fill_nest_halos_from_parent_masked("weasdl", mn_phys%weasdl, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, -1.0D20)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, FN20)
 
       call fill_nest_halos_from_parent_masked("snodi", mn_phys%snodi, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_SEAICE, 0.0D0, -1.0D20)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_SEAICE, 0.0D0, FN20)
 
       call fill_nest_halos_from_parent_masked("weasdi", mn_phys%weasdi, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_SEAICE, 0.0D0, -1.0D20)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_SEAICE, 0.0D0, FN20)
 
     endif
 

--- a/fv3/moving_nest/fv_moving_nest_physics.F90
+++ b/fv3/moving_nest/fv_moving_nest_physics.F90
@@ -104,6 +104,10 @@ module fv_moving_nest_physics_mod
   real, parameter:: real_snan=x'FFF7FFFFFFFFFFFF'
 #endif
 
+  real(kind=kind_phys) :: HUGE   = 9.9692099683868690E36  ! NetCDF float FillValue
+  real(kind=kind_phys) :: FN20   = -1.0E20                ! FillValue of -1.0E20
+  real(kind=kind_phys) :: FP20   = 9.99E20                ! FillValue of 9.99E20
+
   logical :: debug_log = .false.
   logical :: move_physics = .true.       ! Always true, unless developer sets move_physics to .False. here for debugging.
   logical :: move_nsst = .true.          ! Value is reset in fv_moving_nest_main.F90 from namelist options
@@ -513,18 +517,19 @@ contains
           mn_phys%shdmax(i,j) = GFS_Sfcprop%shdmax(im)
           mn_phys%zorl(i,j)   = GFS_Sfcprop%zorl(im)
           mn_phys%zorll(i,j)  = GFS_Sfcprop%zorll(im)
-          mn_phys%zorlwav(i,j)= GFS_Sfcprop%zorlwav(im)
+          mn_phys%zorli(i,j)  = GFS_Sfcprop%zorli(im)
           mn_phys%zorlw(i,j)  = GFS_Sfcprop%zorlw(im)
+          mn_phys%zorlwav(i,j)= GFS_Sfcprop%zorlwav(im)
           mn_phys%usfco(i,j)  = GFS_Sfcprop%usfco(im)
           mn_phys%vsfco(i,j)  = GFS_Sfcprop%vsfco(im)
           mn_phys%tsfco(i,j)  = GFS_Sfcprop%tsfco(im)
           mn_phys%tsfcl(i,j)  = GFS_Sfcprop%tsfcl(im)
           mn_phys%tsfc(i,j)   = GFS_Sfcprop%tsfc(im)
 
-          mn_phys%albdirvis_lnd(i,j)   = GFS_Sfcprop%albdirvis_lnd(im)
-          mn_phys%albdirnir_lnd(i,j)   = GFS_Sfcprop%albdirnir_lnd(im)
-          mn_phys%albdifvis_lnd(i,j)   = GFS_Sfcprop%albdifvis_lnd(im)
-          mn_phys%albdifnir_lnd(i,j)   = GFS_Sfcprop%albdifnir_lnd(im)
+!         mn_phys%albdirvis_lnd(i,j)   = GFS_Sfcprop%albdirvis_lnd(im)
+!         mn_phys%albdirnir_lnd(i,j)   = GFS_Sfcprop%albdirnir_lnd(im)
+!         mn_phys%albdifvis_lnd(i,j)   = GFS_Sfcprop%albdifvis_lnd(im)
+!         mn_phys%albdifnir_lnd(i,j)   = GFS_Sfcprop%albdifnir_lnd(im)
 
           do nv = 1, GFS_Control%ntot2d
             mn_phys%phy_f2d(i,j,nv) = GFS_tbd%phy_f2d(im, nv)
@@ -623,6 +628,13 @@ contains
           do k = GFS_control%lsnow_lsm_lbound, GFS_control%lsoil
             mn_phys%zsnsoxy(i,j,k)    = GFS_sfcprop%zsnsoxy(im,k)
           enddo
+
+          mn_phys%srflag(i,j)     = GFS_sfcprop%srflag(im)
+          mn_phys%snodl(i,j)      = GFS_sfcprop%snodl(im)
+          mn_phys%weasdl(i,j)     = GFS_sfcprop%weasdl(im)
+          mn_phys%snodi(i,j)      = GFS_sfcprop%snodi(im)
+          mn_phys%weasdi(i,j)     = GFS_sfcprop%weasdi(im)
+
         endif
       enddo
     enddo
@@ -655,6 +667,8 @@ contains
     real(kind=kind_phys) :: zsns_default(-2:4) !local for Noah MP
     type(fv_moving_nest_physics_type), pointer       :: mn_phys
 
+    integer, parameter :: M_WATER = 0, M_LAND = 1, M_SEAICE = 2
+
     this_pe = mpp_pe()
     mn_phys => Moving_nest(n)%mn_phys
     dzs      = (/0.1,0.3,0.6,1.0/)             ! 4 layer soil thickness
@@ -686,11 +700,17 @@ contains
 
           if (move_physics) then
             ! Surface properties
-            do k = 1, GFS_control%lsoil
-              GFS_sfcprop%smc(im,k) = mn_phys%smc(i,j,k)
-              GFS_sfcprop%stc(im,k) = mn_phys%stc(i,j,k)
-              GFS_sfcprop%slc(im,k) = mn_phys%slc(i,j,k)
-            enddo
+            if (nint(GFS_sfcprop%slmsk(im)) .eq. M_LAND ) then
+              do k = 1, GFS_control%lsoil
+                GFS_sfcprop%smc(im,k) = mn_phys%smc(i,j,k)
+                GFS_sfcprop%stc(im,k) = mn_phys%stc(i,j,k)
+                GFS_sfcprop%slc(im,k) = mn_phys%slc(i,j,k)
+              enddo
+            else
+              GFS_sfcprop%smc(im,:) = 1.0
+              GFS_sfcprop%stc(im,:) = -1.0D20
+              GFS_sfcprop%slc(im,:) = 1.0
+            endif
 
             ! EMIS PATCH - Force to positive at all locations.
             if (mn_phys%emis_lnd(i,j) .ge. 0.0) then
@@ -732,42 +752,14 @@ contains
             GFS_sfcprop%shdmin(im) = mn_phys%shdmin(i,j)
             GFS_sfcprop%shdmax(im) = mn_phys%shdmax(i,j)
 
-            ! Set roughness lengths to physically reasonable values if they have fill value (possible at coastline)
-            ! sea/land mask array (sea:0,land:1,sea-ice:2)
-            if (nint(GFS_sfcprop%slmsk(im)) .eq. 1 .and. mn_phys%zorll(i,j) .gt. 1e6) then
-              GFS_sfcprop%zorll(im)  = 82.0   !
-            else
-              GFS_sfcprop%zorll(im)  = mn_phys%zorll(i,j)
-            endif
+            GFS_sfcprop%zorl(im)   = mn_phys%zorl(i,j)
+            GFS_sfcprop%zorll(im)  = mn_phys%zorll(i,j)
+            GFS_sfcprop%zorli(im)  = mn_phys%zorli(i,j)
+            GFS_sfcprop%zorlw(im)  = mn_phys%zorlw(i,j)
+            GFS_sfcprop%zorlwav(im) = mn_phys%zorlwav(i,j)
 
-            if (nint(GFS_sfcprop%slmsk(im)) .eq. 0 .and. mn_phys%zorlw(i,j) .gt. 1e6) then
-              GFS_sfcprop%zorlw(im)  = 83.0   !
-            else
-              GFS_sfcprop%zorlw(im)  = mn_phys%zorlw(i,j)
-            endif
-
-            if (nint(GFS_sfcprop%slmsk(im)) .eq. 0 .and. mn_phys%zorlwav(i,j) .gt. 1e6) then
-              GFS_sfcprop%zorlwav(im)  = 84.0   !
-            else
-              GFS_sfcprop%zorlwav(im)  = mn_phys%zorlwav(i,j)
-            endif
-
-            if (mn_phys%zorl(i,j) .gt. 1e6) then
-              GFS_sfcprop%zorl(im)   = 85.0
-            else
-              GFS_sfcprop%zorl(im)   = mn_phys%zorl(i,j)
-            endif
-
-            if (nint(GFS_sfcprop%slmsk(im)) .eq. 0 .and. mn_phys%usfco(i,j) .gt. 1e6) then
-              GFS_sfcprop%usfco(im)  = 0.0
-            else
-              GFS_sfcprop%usfco(im)  = mn_phys%usfco(i,j)
-            endif
-            if (nint(GFS_sfcprop%slmsk(im)) .eq. 0 .and. mn_phys%vsfco(i,j) .gt. 1e6) then
-              GFS_sfcprop%vsfco(im)  = 0.0
-            else
-              GFS_sfcprop%vsfco(im)  = mn_phys%vsfco(i,j)
-            endif
+            GFS_sfcprop%usfco(im)  = mn_phys%usfco(i,j)
+            GFS_sfcprop%vsfco(im)  = mn_phys%vsfco(i,j)
 
             GFS_sfcprop%tsfco(im)  = mn_phys%tsfco(i,j)
             GFS_sfcprop%tsfcl(im)  = mn_phys%tsfcl(i,j)
@@ -836,7 +828,21 @@ contains
 
           if (GFS_control%lsm == GFS_control%lsm_noahmp) then
 
-            GFS_sfcprop%scolor(im)     = mn_phys%soilcolor(i,j)
+            do k = 1, GFS_control%lsoil
+              GFS_sfcprop%smoiseq(im,k) = mn_phys%smoiseq(i,j,k)
+            enddo
+
+          ! do k = GFS_control%lsnow_lsm_lbound, GFS_control%lsnow_lsm_ubound
+          !   GFS_sfcprop%snicexy(im,k) = mn_phys%snicexy(i,j,k)
+          !   GFS_sfcprop%snliqxy(im,k) = mn_phys%snliqxy(i,j,k)
+          !   GFS_sfcprop%tsnoxy(im,k)  = mn_phys%tsnoxy(i,j,k)
+          ! enddo
+
+          ! do k = GFS_control%lsnow_lsm_lbound, GFS_control%lsoil
+          !   GFS_sfcprop%zsnsoxy(im,k) = mn_phys%zsnsoxy(i,j,k)
+          ! enddo
+
+            GFS_sfcprop%scolor(im)     = nint(mn_phys%soilcolor(i,j)) ! scolor is integer
             GFS_sfcprop%tgxy(im)       = mn_phys%tgxy(i,j)
             GFS_sfcprop%cmxy(im)       = mn_phys%cmxy(i,j)
             GFS_sfcprop%chxy(im)       = mn_phys%chxy(i,j)
@@ -859,8 +865,14 @@ contains
             GFS_sfcprop%smcwtdxy(im)   = mn_phys%smcwtdxy(i,j)
             GFS_sfcprop%deeprechxy(im) = mn_phys%deeprechxy(i,j)
             GFS_sfcprop%rechxy(im)     = mn_phys%rechxy(i,j)
+            GFS_sfcprop%snowxy(im)     = mn_phys%snowxy(i,j)
             GFS_sfcprop%snowd(im)      = mn_phys%snowd(i,j)
             GFS_sfcprop%weasd(im)      = mn_phys%weasd(i,j)
+            GFS_sfcprop%sncovr(im)     = mn_phys%sncovr(i,j)
+
+            GFS_sfcprop%srflag(im)     = mn_phys%srflag(i,j)
+            GFS_sfcprop%snodl(im)      = mn_phys%snodl(i,j)
+            GFS_sfcprop%weasdl(im)     = mn_phys%weasdl(i,j)
 
             ! Vegetation variables: perform some bounds checks in case nest vegetated grids inherit from non-veg parent
 
@@ -885,24 +897,34 @@ contains
             endif
 
             ! ICEFIX handle tiice
-            do k = 1, GFS_control%kice
-              GFS_sfcprop%tiice(im,k) = mn_phys%tiice(i,j,k)
-            enddo
+            if (nint(GFS_sfcprop%slmsk(im)) .eq. M_SEAICE) then
+              do k = 1, GFS_control%kice
+                GFS_sfcprop%tiice(im,k) = mn_phys%tiice(i,j,k)
+              enddo
+            else if (nint(GFS_sfcprop%slmsk(im)) .eq. M_WATER) then
+              GFS_sfcprop%tiice(im,:)    = 271.21
+            else
+              GFS_sfcprop%tiice(im,:)    = 0.
+            endif
+
             if (mn_phys%tisfc(i,j) .lt. 240.0 .or. mn_phys%tisfc(i,j) .gt. 285.0 ) then
               mn_phys%tisfc(i,j) = 273.15 - 5.0
             endif
             GFS_sfcprop%tisfc(im) = mn_phys%tisfc(i,j)
-            GFS_sfcprop%sncovr(im) = mn_phys%sncovr(i,j)
 
-            GFS_sfcprop%fice(im) = mn_phys%fice(i,j)
-            GFS_sfcprop%hice(im) = mn_phys%hice(i,j)
+            if (nint(GFS_sfcprop%slmsk(im)) .eq. M_SEAICE) then
+              GFS_sfcprop%fice(im)       = mn_phys%fice(i,j)
+              GFS_sfcprop%hice(im)       = mn_phys%hice(i,j)
+              GFS_sfcprop%snodi(im)      = mn_phys%snodi(i,j)
+              GFS_sfcprop%weasdi(im)     = mn_phys%weasdi(i,j)
+            else
+              GFS_sfcprop%fice(im)       = 0.
+              GFS_sfcprop%hice(im)       = 0.
+              GFS_sfcprop%snodi(im)      = -1.0D20
+              GFS_sfcprop%weasdi(im)     = -1.0D20
+            endif
 
-            do k = 1, GFS_control%lsoil
-              GFS_sfcprop%smoiseq(im,k) = mn_phys%smoiseq(i,j,k)
-            enddo
-
-            ! Reset over land only
-            if (nint(GFS_sfcprop%slmsk(im)) .eq. 1) then
+            if (nint(GFS_sfcprop%slmsk(im)) .eq. M_LAND) then
 
             do k = 1, GFS_control%lsoil
               GFS_sfcprop%smc(im,k) = min(GFS_sfcprop%smc(im,k),porosity(GFS_sfcprop%stype(im))-0.01)
@@ -1006,11 +1028,57 @@ contains
               endif
             endif
 
-            endif ! Reset over land only
-          endif
+            else ! Reset variables for non land points
+
+            GFS_sfcprop%smoiseq(im,:)  = 9.99E+20
+            GFS_sfcprop%snicexy(im,:)  = 9.99E+20
+            GFS_sfcprop%snliqxy(im,:)  = 9.99E+20
+            GFS_sfcprop%tsnoxy(im,:)   = 9.99E+20
+            GFS_sfcprop%zsnsoxy(im,:)  = 9.99E+20
+
+            GFS_sfcprop%scolor(im)     = 0        ! scolor is integer
+            GFS_sfcprop%tgxy(im)       = 9.99E+20
+            GFS_sfcprop%cmxy(im)       = 9.99E+20
+            GFS_sfcprop%chxy(im)       = 9.99E+20
+            GFS_sfcprop%sneqvoxy(im)   = 9.99E+20
+            GFS_sfcprop%alboldxy(im)   = 9.99E+20
+            GFS_sfcprop%qsnowxy(im)    = 9.99E+20
+            GFS_sfcprop%wslakexy(im)   = 9.99E+20
+            GFS_sfcprop%zwtxy(im)      = 9.99E+20
+            GFS_sfcprop%waxy(im)       = 9.99E+20
+            GFS_sfcprop%wtxy(im)       = 9.99E+20
+            GFS_sfcprop%lfmassxy(im)   = 9.99E+20
+            GFS_sfcprop%rtmassxy(im)   = 9.99E+20
+            GFS_sfcprop%stmassxy(im)   = 9.99E+20
+            GFS_sfcprop%woodxy(im)     = 9.99E+20
+            GFS_sfcprop%stblcpxy(im)   = 9.99E+20
+            GFS_sfcprop%fastcpxy(im)   = 9.99E+20
+            GFS_sfcprop%xsaixy(im)     = 9.99E+20
+            GFS_sfcprop%xlaixy(im)     = 9.99E+20
+            GFS_sfcprop%taussxy(im)    = 9.99E+20
+            GFS_sfcprop%smcwtdxy(im)   = 9.99E+20
+            GFS_sfcprop%deeprechxy(im) = 9.99E+20
+            GFS_sfcprop%rechxy(im)     = 9.99E+20
+            GFS_sfcprop%tvxy(im)       = 9.99E+20
+            GFS_sfcprop%tahxy(im)      = 9.99E+20
+            GFS_sfcprop%fwetxy(im)     = 9.99E+20
+            GFS_sfcprop%canicexy(im)   = 9.99E+20
+            GFS_sfcprop%canliqxy(im)   = 9.99E+20
+            GFS_sfcprop%eahxy(im)      = 9.99E+20
+            GFS_sfcprop%snowxy(im)     = 9.99E+20
+            GFS_sfcprop%snowd(im)      = 0.
+            GFS_sfcprop%weasd(im)      = 0.
+            GFS_sfcprop%sncovr(im)     = 0.
+
+            GFS_sfcprop%snodl(im)      = -1.0D20
+            GFS_sfcprop%weasdl(im)     = -1.0D20
+
+            endif ! if (nint(GFS_sfcprop%slmsk(im)) .eq. M_LAND) then
+
+          endif ! if (GFS_control%lsm == GFS_control%lsm_noahmp) then
 
           ! Check if stype and vtype are properly set for land points. Set to reasonable values if they have fill values.
-          if ( (nint(GFS_sfcprop%slmsk(im)) .eq. 1) ) then
+          if ( (nint(GFS_sfcprop%slmsk(im)) .eq. M_LAND) ) then
             if (GFS_sfcprop%vtype(im) .lt. 0.5) then
               GFS_sfcprop%vtype(im) = 7    ! Force to grassland
             endif
@@ -1082,21 +1150,34 @@ contains
         is_fine_pe, nest_domain, position)
 
     if (move_physics) then
+      call fill_nest_halos_from_parent("tsfco", mn_phys%tsfco, interp_type, Atm(child_grid_num)%neststruct%wt_h, &
+          Atm(child_grid_num)%neststruct%ind_h, &
+          x_refine, y_refine, &
+          is_fine_pe, nest_domain, position)
+      call fill_nest_halos_from_parent("tsfcl", mn_phys%tsfcl, interp_type, Atm(child_grid_num)%neststruct%wt_h, &
+          Atm(child_grid_num)%neststruct%ind_h, &
+          x_refine, y_refine, &
+          is_fine_pe, nest_domain, position)
+      call fill_nest_halos_from_parent("tsfc", mn_phys%tsfc, interp_type, Atm(child_grid_num)%neststruct%wt_h, &
+          Atm(child_grid_num)%neststruct%ind_h, &
+          x_refine, y_refine, &
+          is_fine_pe, nest_domain, position)
+
       ! Default - Arbitrary value 0.3
       call fill_nest_halos_from_parent_masked("smc", mn_phys%smc, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, &
           x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, 1, GFS_Control%lsoil, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.3D0)
+          is_fine_pe, nest_domain, position, 1, GFS_Control%lsoil, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.3D0, 1.0D0)
       ! Defaults - use surface temperature to set soil temperature at each level
       call fill_nest_halos_from_parent_masked("stc", mn_phys%stc, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, &
           x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, 1, GFS_Control%lsoil, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, mn_phys%ts)
+          is_fine_pe, nest_domain, position, 1, GFS_Control%lsoil, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, mn_phys%tsfc, mn_phys%tsfc)
       ! Default - Arbitrary value 0.3
       call fill_nest_halos_from_parent_masked("slc", mn_phys%slc, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, &
           x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, 1, GFS_Control%lsoil, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.3D0)
+          is_fine_pe, nest_domain, position, 1, GFS_Control%lsoil, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.3D0, 1D0)
 
       call fill_nest_halos_from_parent("phy_f2d", mn_phys%phy_f2d, interp_type, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, &
@@ -1121,17 +1202,17 @@ contains
       call fill_nest_halos_from_parent_masked("emis_lnd", mn_phys%emis_lnd, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, &
           x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.5D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.5D0, 0.95D0)
 
       call fill_nest_halos_from_parent_masked("emis_ice", mn_phys%emis_ice, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, &
           x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_SEAICE, 0.5D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_SEAICE, 0.5D0, 0.96D0)
 
       call fill_nest_halos_from_parent_masked("emis_wat", mn_phys%emis_wat, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, &
           x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_WATER, 0.5D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_WATER, 0.5D0, 0.97D0)
 
       !call fill_nest_halos_from_parent("sfalb_lnd_bck", mn_phys%sfalb_lnd_bck, interp_type, Atm(child_grid_num)%neststruct%wt_h, &
       !     Atm(child_grid_num)%neststruct%ind_h, &
@@ -1190,10 +1271,10 @@ contains
 !          is_fine_pe, nest_domain, position)
       call fill_nest_halos_from_parent_masked("canopy", mn_phys%canopy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 0.0D0)
       call fill_nest_halos_from_parent_masked("vegfrac", mn_phys%vegfrac, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.50D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.50D0, 0.0D0)
 
       call fill_nest_halos_from_parent("uustar", mn_phys%uustar, interp_type, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, &
@@ -1207,62 +1288,53 @@ contains
           Atm(child_grid_num)%neststruct%ind_h, &
           x_refine, y_refine, &
           is_fine_pe, nest_domain, position)
+
       call fill_nest_halos_from_parent("zorl", mn_phys%zorl, interp_type, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, &
           x_refine, y_refine, &
           is_fine_pe, nest_domain, position)
-
       call fill_nest_halos_from_parent_masked("zorll", mn_phys%zorll, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, &
           x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, 1, 86.0D0)
-      call fill_nest_halos_from_parent_masked("zorlwav", mn_phys%zorlwav, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, mn_phys%zorl, mn_phys%zorl)
+      call fill_nest_halos_from_parent_masked("zorli", mn_phys%zorli, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, &
           x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, 0, 77.0D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_SEAICE, mn_phys%zorl, mn_phys%zorl)
       call fill_nest_halos_from_parent_masked("zorlw", mn_phys%zorlw, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, &
           x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, 0, 78.0D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_WATER, mn_phys%zorl, mn_phys%zorl)
+      call fill_nest_halos_from_parent("zorlwav", mn_phys%zorlwav, interp_type, Atm(child_grid_num)%neststruct%wt_h, &
+          Atm(child_grid_num)%neststruct%ind_h, &
+          x_refine, y_refine, &
+          is_fine_pe, nest_domain, position)
 
       call fill_nest_halos_from_parent_masked("usfco", mn_phys%usfco, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, &
           x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, 0, 0.0D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_WATER, 0.0D0, 0.0D0)
       call fill_nest_halos_from_parent_masked("vsfco", mn_phys%vsfco, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, &
           x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, 0, 0.0D0)
-
-      call fill_nest_halos_from_parent("tsfco", mn_phys%tsfco, interp_type, Atm(child_grid_num)%neststruct%wt_h, &
-          Atm(child_grid_num)%neststruct%ind_h, &
-          x_refine, y_refine, &
-          is_fine_pe, nest_domain, position)
-      call fill_nest_halos_from_parent("tsfcl", mn_phys%tsfcl, interp_type, Atm(child_grid_num)%neststruct%wt_h, &
-          Atm(child_grid_num)%neststruct%ind_h, &
-          x_refine, y_refine, &
-          is_fine_pe, nest_domain, position)
-      call fill_nest_halos_from_parent("tsfc", mn_phys%tsfc, interp_type, Atm(child_grid_num)%neststruct%wt_h, &
-          Atm(child_grid_num)%neststruct%ind_h, &
-          x_refine, y_refine, &
-          is_fine_pe, nest_domain, position)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_WATER, 0.0D0, 0.0D0)
 
       call fill_nest_halos_from_parent_masked("albdirvis_lnd", mn_phys%albdirvis_lnd, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, &
           x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.5D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.5D0, 0.2D0)
       call fill_nest_halos_from_parent_masked("albdirnir_lnd", mn_phys%albdirnir_lnd, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, &
           x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.5D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.5D0, 0.2D0)
       call fill_nest_halos_from_parent_masked("albdifvis_lnd", mn_phys%albdifvis_lnd, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, &
           x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.5D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.5D0, 0.2D0)
       call fill_nest_halos_from_parent_masked("albdifnir_lnd", mn_phys%albdifnir_lnd, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, &
           x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.5D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.5D0, 0.2D0)
 
       call fill_nest_halos_from_parent("cv", mn_phys%cv, interp_type, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, &
@@ -1362,167 +1434,167 @@ contains
       !  Default changed to 10 based on suggestion from Mike Barlage; more middle of the spectrum value.
       call fill_nest_halos_from_parent_masked("soilcol", mn_phys%soilcolor, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 10.0D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 10.0D0, 0.0D0)
 
       call fill_nest_halos_from_parent_masked("snowxy", mn_phys%snowxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
       call fill_nest_halos_from_parent_masked("tvxy", mn_phys%tvxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, mn_phys%ts)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, mn_phys%tsfc, mn_phys%tsfc)
       call fill_nest_halos_from_parent_masked("tgxy", mn_phys%tgxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, mn_phys%ts)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, mn_phys%tsfc, mn_phys%tsfc)
 
       call fill_nest_halos_from_parent_masked("canicexy", mn_phys%canicexy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
       call fill_nest_halos_from_parent_masked("canliqxy", mn_phys%canliqxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
 
       call fill_nest_halos_from_parent_masked("eahxy", mn_phys%eahxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 2000.0D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 2000.0D0, 9.99D20)
 
       call fill_nest_halos_from_parent_masked("tahxy", mn_phys%tahxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, mn_phys%ts)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, mn_phys%tsfc, mn_phys%tsfc)
 
       ! TODO get realistic default value here  -- bulk momentum drag coefficient
       call fill_nest_halos_from_parent_masked("cmxy", mn_phys%cmxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 2.4D-3)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 2.4D-3, 9.99D20)
 
       ! TODO get realistic default value here  -- bulk sensible heat drag coefficient
       call fill_nest_halos_from_parent_masked("chxy", mn_phys%chxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 2.4D-3)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 2.4D-3, 9.99D20)
 
       ! wetted or snowed fraction of the canopy
       call fill_nest_halos_from_parent_masked("fwetxy", mn_phys%fwetxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
 
       ! snow mass at last time step[mm h2o]
       call fill_nest_halos_from_parent_masked("sneqvoxy", mn_phys%sneqvoxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
 
       ! Albedo assuming deep snow on prev timestep - default to 0.65
       call fill_nest_halos_from_parent_masked("alboldxy", mn_phys%alboldxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.65D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.65D0, 9.99D20)
 
       ! Liquid equivalent snow - default to 0
       call fill_nest_halos_from_parent_masked("qsnowxy", mn_phys%qsnowxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
 
       ! Lake water storage [mm] -- TODO find better default
       call fill_nest_halos_from_parent_masked("wslakexy", mn_phys%wslakexy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
 
       ! Water table depth - set to 2.5, cold start value
       call fill_nest_halos_from_parent_masked("zwtxy", mn_phys%zwtxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 2.5D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 2.5D0, 9.99D20)
 
       ! Water storage in aquifer - set to 4900.0, cold start value
       call fill_nest_halos_from_parent_masked("waxy", mn_phys%waxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 4900.0D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 4900.0D0, 9.99D20)
       ! Water storage in aquifer and saturated soil - set to 4900.0, cold start value
       call fill_nest_halos_from_parent_masked("wtxy", mn_phys%wtxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 4900.0D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 4900.0D0, 9.99D20)
 
       ! Leaf mass [g/m2] -- TODO find better default
       call fill_nest_halos_from_parent_masked("lfmassxy", mn_phys%lfmassxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
       ! Fine root mass [g/m2] -- TODO find better default
       call fill_nest_halos_from_parent_masked("rtmassxy", mn_phys%rtmassxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
       ! Stem mass [g/m2] -- TODO find better default
       call fill_nest_halos_from_parent_masked("stmassxy", mn_phys%stmassxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
       ! Wood mass [g/m2] -- TODO find better default
       call fill_nest_halos_from_parent_masked("woodxy", mn_phys%woodxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
 
       ! stable carbon in deep soil [g/m2] -- TODO find a better default
       call fill_nest_halos_from_parent_masked("stblcpxy", mn_phys%stblcpxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
       ! short-lived carbon, shallow soil [g/m2] -- TODO find a better default
       call fill_nest_halos_from_parent_masked("fastcpxy", mn_phys%fastcpxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
 
       ! stem area index [m2/m2] -- TODO find a better default
       call fill_nest_halos_from_parent_masked("xsaixy", mn_phys%xsaixy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
       ! leaf area index [m2/m2] -- TODO find a better default
       call fill_nest_halos_from_parent_masked("xlaixy", mn_phys%xlaixy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
 
       ! snow age factor [-] -- TODO find a better default
       call fill_nest_halos_from_parent_masked("taussxy", mn_phys%taussxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
 
       ! soil moisture content in the layer to the water table when deep -- TODO find a better default
       call fill_nest_halos_from_parent_masked("smcwtdxy", mn_phys%smcwtdxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
 
       ! recharge to the water table when deep -- TODO find a better default
       call fill_nest_halos_from_parent_masked("deeprechxy", mn_phys%deeprechxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
       ! recharge to the water table  -- TODO find a better default
       call fill_nest_halos_from_parent_masked("rechxy", mn_phys%rechxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
 
       call fill_nest_halos_from_parent_masked("snicexy", mn_phys%snicexy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
           is_fine_pe, nest_domain, position, GFS_control%lsnow_lsm_lbound, GFS_control%lsnow_lsm_ubound, &
-          mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0)
+          mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
 
       call fill_nest_halos_from_parent_masked("snliqxy", mn_phys%snliqxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
           is_fine_pe, nest_domain, position, GFS_control%lsnow_lsm_lbound,  GFS_control%lsnow_lsm_ubound, &
-          mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0)
+          mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
 
       ! surface snow thickness water equivalent over land - - default to 0
       call fill_nest_halos_from_parent_masked("snowd", mn_phys%snowd, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 0.0D0)
 
       ! Temperature in surface snow -- TODO notes say default to 0, but I will put 273.15K
       call fill_nest_halos_from_parent_masked("tsnoxy", mn_phys%tsnoxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
           is_fine_pe, nest_domain, position, GFS_control%lsnow_lsm_lbound, GFS_control%lsnow_lsm_ubound, &
           !mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 273.15D0)
-          mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0)
+          mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 9.99D20)
 
       ! water equivalent accumulated snow depth over land - - default to 0
       call fill_nest_halos_from_parent_masked("weasd", mn_phys%weasd, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 0.0D0)
 
       call fill_nest_halos_from_parent_masked("smoiseq", mn_phys%smoiseq, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, &
           x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, 1, GFS_control%lsoil, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.3D0)
+          is_fine_pe, nest_domain, position, 1, GFS_control%lsoil, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.3D0, 9.99D20)
 
       call fill_nest_halos_from_parent_masked("zsnsoxy", mn_phys%zsnsoxy, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
@@ -1533,20 +1605,39 @@ contains
       call fill_nest_halos_from_parent_masked("tiice", mn_phys%tiice, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
           is_fine_pe, nest_domain, position, 1, 2, & !! kice
-          mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_SEAICE, mn_phys%ts)
+          mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_SEAICE, mn_phys%tsfc, mn_phys%tsfc)
       call fill_nest_halos_from_parent_masked("tisfc", mn_phys%tisfc, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_SEAICE, mn_phys%ts)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_SEAICE, mn_phys%tsfc, mn_phys%tsfc)
       call fill_nest_halos_from_parent_masked("sncovr", mn_phys%sncovr, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, 0.0D0)
 
       call fill_nest_halos_from_parent_masked("fice", mn_phys%fice, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_SEAICE, 0.0D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_SEAICE, 1.0D0, 0.0D0)
       call fill_nest_halos_from_parent_masked("hice", mn_phys%hice, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
           Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
-          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_SEAICE, 0.0D0)
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_SEAICE, 0.1D0, 0.0D0)
+
+      call fill_nest_halos_from_parent("srflag", mn_phys%srflag, interp_type, Atm(child_grid_num)%neststruct%wt_h, &
+          Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, is_fine_pe, nest_domain, position)
+
+      call fill_nest_halos_from_parent_masked("snodl", mn_phys%snodl, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
+          Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, -1.0D20)
+
+      call fill_nest_halos_from_parent_masked("weasdl", mn_phys%weasdl, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
+          Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_LAND, 0.0D0, -1.0D20)
+
+      call fill_nest_halos_from_parent_masked("snodi", mn_phys%snodi, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
+          Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_SEAICE, 0.0D0, -1.0D20)
+
+      call fill_nest_halos_from_parent_masked("weasdi", mn_phys%weasdi, interp_type_lmask, Atm(child_grid_num)%neststruct%wt_h, &
+          Atm(child_grid_num)%neststruct%ind_h, x_refine, y_refine, &
+          is_fine_pe, nest_domain, position, mn_phys%slmsk, mn_static%parent_ls%ls_mask_grid, M_SEAICE, 0.0D0, -1.0D20)
 
     endif
 
@@ -1599,8 +1690,9 @@ contains
       call mn_var_fill_intern_nest_halos(mn_phys%shdmax, domain_fine, is_fine_pe)
       call mn_var_fill_intern_nest_halos(mn_phys%zorl, domain_fine, is_fine_pe)
       call mn_var_fill_intern_nest_halos(mn_phys%zorll, domain_fine, is_fine_pe)
-      call mn_var_fill_intern_nest_halos(mn_phys%zorlwav, domain_fine, is_fine_pe)
+      call mn_var_fill_intern_nest_halos(mn_phys%zorli, domain_fine, is_fine_pe)
       call mn_var_fill_intern_nest_halos(mn_phys%zorlw, domain_fine, is_fine_pe)
+      call mn_var_fill_intern_nest_halos(mn_phys%zorlwav, domain_fine, is_fine_pe)
       call mn_var_fill_intern_nest_halos(mn_phys%usfco, domain_fine, is_fine_pe)
       call mn_var_fill_intern_nest_halos(mn_phys%vsfco, domain_fine, is_fine_pe)
       call mn_var_fill_intern_nest_halos(mn_phys%tsfco, domain_fine, is_fine_pe)
@@ -1683,6 +1775,12 @@ contains
 
       call mn_var_fill_intern_nest_halos(mn_phys%fice, domain_fine, is_fine_pe)
       call mn_var_fill_intern_nest_halos(mn_phys%hice, domain_fine, is_fine_pe)
+
+      call mn_var_fill_intern_nest_halos(mn_phys%srflag, domain_fine, is_fine_pe)
+      call mn_var_fill_intern_nest_halos(mn_phys%snodl, domain_fine, is_fine_pe)
+      call mn_var_fill_intern_nest_halos(mn_phys%weasdl, domain_fine, is_fine_pe)
+      call mn_var_fill_intern_nest_halos(mn_phys%snodi, domain_fine, is_fine_pe)
+      call mn_var_fill_intern_nest_halos(mn_phys%weasdi, domain_fine, is_fine_pe)
 
     endif
 
@@ -1779,9 +1877,11 @@ contains
           delta_i_c, delta_j_c, x_refine, y_refine, is_fine_pe, nest_domain, position)
       call mn_var_shift_data(mn_phys%zorll, interp_type, wt_h, Atm(child_grid_num)%neststruct%ind_h, &
           delta_i_c, delta_j_c, x_refine, y_refine, is_fine_pe, nest_domain, position)
-      call mn_var_shift_data(mn_phys%zorlwav, interp_type, wt_h, Atm(child_grid_num)%neststruct%ind_h, &
+      call mn_var_shift_data(mn_phys%zorli, interp_type, wt_h, Atm(child_grid_num)%neststruct%ind_h, &
           delta_i_c, delta_j_c, x_refine, y_refine, is_fine_pe, nest_domain, position)
       call mn_var_shift_data(mn_phys%zorlw, interp_type, wt_h, Atm(child_grid_num)%neststruct%ind_h, &
+          delta_i_c, delta_j_c, x_refine, y_refine, is_fine_pe, nest_domain, position)
+      call mn_var_shift_data(mn_phys%zorlwav, interp_type, wt_h, Atm(child_grid_num)%neststruct%ind_h, &
           delta_i_c, delta_j_c, x_refine, y_refine, is_fine_pe, nest_domain, position)
       call mn_var_shift_data(mn_phys%usfco, interp_type, wt_h, Atm(child_grid_num)%neststruct%ind_h, &
           delta_i_c, delta_j_c, x_refine, y_refine, is_fine_pe, nest_domain, position)
@@ -1933,6 +2033,17 @@ contains
       call mn_var_shift_data(mn_phys%fice, interp_type, wt_h, Atm(child_grid_num)%neststruct%ind_h, &
           delta_i_c, delta_j_c, x_refine, y_refine, is_fine_pe, nest_domain, position)
       call mn_var_shift_data(mn_phys%hice, interp_type, wt_h, Atm(child_grid_num)%neststruct%ind_h, &
+          delta_i_c, delta_j_c, x_refine, y_refine, is_fine_pe, nest_domain, position)
+
+      call mn_var_shift_data(mn_phys%srflag, interp_type, wt_h, Atm(child_grid_num)%neststruct%ind_h, &
+          delta_i_c, delta_j_c, x_refine, y_refine, is_fine_pe, nest_domain, position)
+      call mn_var_shift_data(mn_phys%snodl, interp_type, wt_h, Atm(child_grid_num)%neststruct%ind_h, &
+          delta_i_c, delta_j_c, x_refine, y_refine, is_fine_pe, nest_domain, position)
+      call mn_var_shift_data(mn_phys%weasdl, interp_type, wt_h, Atm(child_grid_num)%neststruct%ind_h, &
+          delta_i_c, delta_j_c, x_refine, y_refine, is_fine_pe, nest_domain, position)
+      call mn_var_shift_data(mn_phys%snodi, interp_type, wt_h, Atm(child_grid_num)%neststruct%ind_h, &
+          delta_i_c, delta_j_c, x_refine, y_refine, is_fine_pe, nest_domain, position)
+      call mn_var_shift_data(mn_phys%weasdi, interp_type, wt_h, Atm(child_grid_num)%neststruct%ind_h, &
           delta_i_c, delta_j_c, x_refine, y_refine, is_fine_pe, nest_domain, position)
 
     endif

--- a/fv3/moving_nest/fv_moving_nest_types.F90
+++ b/fv3/moving_nest/fv_moving_nest_types.F90
@@ -156,7 +156,7 @@ module fv_moving_nest_types_mod
 
     real (kind=kind_phys), _ALLOCATABLE :: zorl (:,:)       _NULL   !< roughness length
     real (kind=kind_phys), _ALLOCATABLE :: zorll (:,:)      _NULL   !< land roughness length
-    !real (kind=kind_phys), _ALLOCATABLE :: zorli (:,:)     _NULL   !< ice surface roughness length ! TODO do we need this?
+    real (kind=kind_phys), _ALLOCATABLE :: zorli (:,:)      _NULL   !< ice surface roughness length
     real (kind=kind_phys), _ALLOCATABLE :: zorlw (:,:)      _NULL   !< wave surface roughness length
     real (kind=kind_phys), _ALLOCATABLE :: zorlwav (:,:)    _NULL   !< wave surface roughness in cm derived from wave model
 
@@ -276,6 +276,12 @@ module fv_moving_nest_types_mod
 
     real (kind=kind_phys), _ALLOCATABLE :: fice (:,:)       _NULL   !< sea ice fraction
     real (kind=kind_phys), _ALLOCATABLE :: hice (:,:)       _NULL   !< sea ice thickness
+
+    real (kind=kind_phys), _ALLOCATABLE ::srflag (:,:)      _NULL
+    real (kind=kind_phys), _ALLOCATABLE ::snodl (:,:)       _NULL
+    real (kind=kind_phys), _ALLOCATABLE ::weasdl (:,:)      _NULL
+    real (kind=kind_phys), _ALLOCATABLE ::snodi (:,:)       _NULL
+    real (kind=kind_phys), _ALLOCATABLE ::weasdi (:,:)      _NULL
 
   end type fv_moving_nest_physics_type
 
@@ -640,8 +646,9 @@ contains
 
       allocate ( mn_phys%zorl(isd:ied, jsd:jed) )
       allocate ( mn_phys%zorll(isd:ied, jsd:jed) )
-      allocate ( mn_phys%zorlwav(isd:ied, jsd:jed) )
+      allocate ( mn_phys%zorli(isd:ied, jsd:jed) )
       allocate ( mn_phys%zorlw(isd:ied, jsd:jed) )
+      allocate ( mn_phys%zorlwav(isd:ied, jsd:jed) )
 
       allocate ( mn_phys%usfco(isd:ied, jsd:jed) )
       allocate ( mn_phys%vsfco(isd:ied, jsd:jed) )
@@ -749,6 +756,13 @@ contains
       allocate ( mn_phys%hice(isd:ied, jsd:jed) )
 
       !allocate ( mn_phys%ustar1(isd:ied, jsd:jed) )
+
+      allocate ( mn_phys%srflag(isd:ied, jsd:jed) )
+      allocate ( mn_phys%snodl(isd:ied, jsd:jed) )
+      allocate ( mn_phys%weasdl(isd:ied, jsd:jed) )
+      allocate ( mn_phys%snodi(isd:ied, jsd:jed) )
+      allocate ( mn_phys%weasdi(isd:ied, jsd:jed) )
+
     endif
 
     mn_phys%ts = +99999.9
@@ -778,8 +792,9 @@ contains
 
       mn_phys%zorl = +99999.9
       mn_phys%zorll = +99999.9
-      mn_phys%zorlwav = +99999.9
+      mn_phys%zorli = +99999.9
       mn_phys%zorlw = +99999.9
+      mn_phys%zorlwav = +99999.9
 
       mn_phys%usfco = +99999.9
       mn_phys%vsfco = +99999.9
@@ -887,6 +902,13 @@ contains
       mn_phys%hice = +99999.9
 
       !mn_phys%ustar1 = +99999.9
+
+      mn_phys%srflag = +99999.9
+      mn_phys%snodl  = +99999.9
+      mn_phys%weasdl = +99999.9
+      mn_phys%snodi  = +99999.9
+      mn_phys%weasdi = +99999.9
+
     endif
 
   end subroutine allocate_fv_moving_nest_physics_type
@@ -927,8 +949,9 @@ contains
 
       deallocate( mn_phys%zorl )
       deallocate( mn_phys%zorll )
-      deallocate( mn_phys%zorlwav )
+      deallocate( mn_phys%zorli )
       deallocate( mn_phys%zorlw )
+      deallocate( mn_phys%zorlwav )
 
       deallocate( mn_phys%usfco )
       deallocate( mn_phys%vsfco )
@@ -1035,6 +1058,12 @@ contains
       deallocate ( mn_phys%sncovr )
       deallocate ( mn_phys%fice )
       deallocate ( mn_phys%hice )
+
+      deallocate ( mn_phys%srflag )
+      deallocate ( mn_phys%snodl )
+      deallocate ( mn_phys%weasdl )
+      deallocate ( mn_phys%snodi )
+      deallocate ( mn_phys%weasdi )
 
     endif
 

--- a/fv3/moving_nest/fv_moving_nest_utils.F90
+++ b/fv3/moving_nest/fv_moving_nest_utils.F90
@@ -509,7 +509,7 @@ contains
 
   end subroutine fill_nest_halos_from_parent_r8_2d
 
-  subroutine fill_nest_halos_from_parent_masked_r8_2d_const(var_name, data_var, interp_type, wt, ind, x_refine, y_refine, is_fine_pe, nest_domain, position, mask_var, parent_mask_var, mask_val, default_val)
+  subroutine fill_nest_halos_from_parent_masked_r8_2d_const(var_name, data_var, interp_type, wt, ind, x_refine, y_refine, is_fine_pe, nest_domain, position, mask_var, parent_mask_var, mask_val, default_val, missing_val)
     character(len=*), intent(in)                :: var_name
     real*8, allocatable, intent(inout)          :: data_var(:,:)
     integer, intent(in)                         :: interp_type
@@ -523,6 +523,10 @@ contains
     real, allocatable, intent(in)               :: parent_mask_var(:,:)
     integer, intent(in)                         :: mask_val
     real*8, intent(in)                          :: default_val
+    real*8, intent(in), optional                :: missing_val
+
+    !Local variables
+    real*8                                      :: missloc_val
 
     real*8, dimension(:,:), allocatable :: nbuffer, sbuffer, ebuffer, wbuffer
     type(bbox)                          :: north_fine, north_coarse
@@ -531,6 +535,12 @@ contains
     type(bbox)                          :: west_fine, west_coarse
     integer                             :: this_pe
     integer                             :: nest_level = 1  ! TODO allow to vary
+
+    if (present(missing_val)) then
+      missloc_val = missing_val
+    else
+      missloc_val = default_val
+    endif
 
     this_pe = mpp_pe()
 
@@ -556,10 +566,10 @@ contains
       !!
       !!===========================================================
 
-      call fill_nest_from_buffer_masked(var_name, interp_type, data_var, nbuffer, north_fine, north_coarse, NORTH, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_val)
-      call fill_nest_from_buffer_masked(var_name, interp_type, data_var, sbuffer, south_fine, south_coarse, SOUTH, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_val)
-      call fill_nest_from_buffer_masked(var_name, interp_type, data_var, ebuffer, east_fine, east_coarse, EAST, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_val)
-      call fill_nest_from_buffer_masked(var_name, interp_type, data_var, wbuffer, west_fine, west_coarse, WEST, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_val)
+      call fill_nest_from_buffer_masked(var_name, interp_type, data_var, nbuffer, north_fine, north_coarse, NORTH, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_val, missloc_val)
+      call fill_nest_from_buffer_masked(var_name, interp_type, data_var, sbuffer, south_fine, south_coarse, SOUTH, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_val, missloc_val)
+      call fill_nest_from_buffer_masked(var_name, interp_type, data_var, ebuffer, east_fine, east_coarse, EAST, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_val, missloc_val)
+      call fill_nest_from_buffer_masked(var_name, interp_type, data_var, wbuffer, west_fine, west_coarse, WEST, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_val, missloc_val)
 
     endif
 
@@ -570,7 +580,7 @@ contains
 
   end subroutine fill_nest_halos_from_parent_masked_r8_2d_const
 
-  subroutine fill_nest_halos_from_parent_masked_r8_2d_2d(var_name, data_var, interp_type, wt, ind, x_refine, y_refine, is_fine_pe, nest_domain, position, mask_var, parent_mask_var, mask_val, default_grid)
+  subroutine fill_nest_halos_from_parent_masked_r8_2d_2d(var_name, data_var, interp_type, wt, ind, x_refine, y_refine, is_fine_pe, nest_domain, position, mask_var, parent_mask_var, mask_val, default_grid, missing_grid)
     character(len=*), intent(in)                :: var_name
     real*8, allocatable, intent(inout)          :: data_var(:,:)
     integer, intent(in)                         :: interp_type
@@ -583,8 +593,11 @@ contains
     real, allocatable, intent(in)             :: mask_var(:,:)
     real, allocatable, intent(in)             :: parent_mask_var(:,:)
     integer, intent(in)                         :: mask_val
-    real, allocatable, intent(in)               :: default_grid(:,:)
+    real*8, allocatable, intent(in)             :: default_grid(:,:)
+    real*8, allocatable, intent(in), optional   :: missing_grid(:,:)
 
+    !local variables
+    real*8, allocatable                         :: missloc_grid(:,:)
     real*8, dimension(:,:), allocatable :: nbuffer, sbuffer, ebuffer, wbuffer
     type(bbox)                          :: north_fine, north_coarse
     type(bbox)                          :: south_fine, south_coarse
@@ -592,6 +605,13 @@ contains
     type(bbox)                          :: west_fine, west_coarse
     integer                             :: this_pe
     integer                             :: nest_level = 1  ! TODO allow to vary
+
+    allocate(missloc_grid, source=default_grid)
+    if  (present(missing_grid)) then
+      missloc_grid = missing_grid
+    else
+      missloc_grid = default_grid
+    endif
 
     this_pe = mpp_pe()
 
@@ -617,10 +637,10 @@ contains
       !!
       !!===========================================================
 
-      call fill_nest_from_buffer_masked(var_name, interp_type, data_var, nbuffer, north_fine, north_coarse, NORTH, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_grid)
-      call fill_nest_from_buffer_masked(var_name, interp_type, data_var, sbuffer, south_fine, south_coarse, SOUTH, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_grid)
-      call fill_nest_from_buffer_masked(var_name, interp_type, data_var, ebuffer, east_fine, east_coarse, EAST, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_grid)
-      call fill_nest_from_buffer_masked(var_name, interp_type, data_var, wbuffer, west_fine, west_coarse, WEST, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_grid)
+      call fill_nest_from_buffer_masked(var_name, interp_type, data_var, nbuffer, north_fine, north_coarse, NORTH, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_grid, missloc_grid)
+      call fill_nest_from_buffer_masked(var_name, interp_type, data_var, sbuffer, south_fine, south_coarse, SOUTH, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_grid, missloc_grid)
+      call fill_nest_from_buffer_masked(var_name, interp_type, data_var, ebuffer, east_fine, east_coarse, EAST, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_grid, missloc_grid)
+      call fill_nest_from_buffer_masked(var_name, interp_type, data_var, wbuffer, west_fine, west_coarse, WEST, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_grid, missloc_grid)
 
     endif
 
@@ -628,10 +648,11 @@ contains
     deallocate(sbuffer)
     deallocate(ebuffer)
     deallocate(wbuffer)
+    deallocate(missloc_grid)
 
   end subroutine fill_nest_halos_from_parent_masked_r8_2d_2d
 
-  subroutine fill_nest_halos_from_parent_masked_r8_3d_lowhighz_const(var_name, data_var, interp_type, wt, ind, x_refine, y_refine, is_fine_pe, nest_domain, position, low_z, high_z, mask_var, parent_mask_var, mask_val, default_val)
+  subroutine fill_nest_halos_from_parent_masked_r8_3d_lowhighz_const(var_name, data_var, interp_type, wt, ind, x_refine, y_refine, is_fine_pe, nest_domain, position, low_z, high_z, mask_var, parent_mask_var, mask_val, default_val, missing_val)
     character(len=*), intent(in)                :: var_name
     real*8, allocatable, intent(inout)          :: data_var(:,:,:)
     integer, intent(in)                         :: interp_type
@@ -645,16 +666,24 @@ contains
     real, allocatable, intent(in)             :: parent_mask_var(:,:)
     integer, intent(in)                         :: mask_val
     real*8, intent(in)                          :: default_val
+    real*8, intent(in), optional                :: missing_val
 
+    ! Local variables
     real*8                          :: default_vector(low_z:high_z)
+    real*8                          :: missloc_vector(low_z:high_z)
 
     default_vector = default_val
+    if (present(missing_val)) then
+      missloc_vector = missing_val
+    else
+      missloc_vector = default_val
+    endif
 
-    call fill_nest_halos_from_parent_masked_r8_3d_lowhighz_1d(var_name, data_var, interp_type, wt, ind, x_refine, y_refine, is_fine_pe, nest_domain, position, low_z, high_z, mask_var, parent_mask_var, mask_val, default_vector)
+    call fill_nest_halos_from_parent_masked_r8_3d_lowhighz_1d(var_name, data_var, interp_type, wt, ind, x_refine, y_refine, is_fine_pe, nest_domain, position, low_z, high_z, mask_var, parent_mask_var, mask_val, default_vector, missloc_vector)
 
   end subroutine fill_nest_halos_from_parent_masked_r8_3d_lowhighz_const
 
-  subroutine fill_nest_halos_from_parent_masked_r8_3d_lowhighz_1d(var_name, data_var, interp_type, wt, ind, x_refine, y_refine, is_fine_pe, nest_domain, position, low_z, high_z, mask_var, parent_mask_var, mask_val, default_val)
+  subroutine fill_nest_halos_from_parent_masked_r8_3d_lowhighz_1d(var_name, data_var, interp_type, wt, ind, x_refine, y_refine, is_fine_pe, nest_domain, position, low_z, high_z, mask_var, parent_mask_var, mask_val, default_val, missing_val)
     character(len=*), intent(in)                :: var_name
     real*8, allocatable, intent(inout)          :: data_var(:,:,:)
     integer, intent(in)                         :: interp_type
@@ -668,6 +697,10 @@ contains
     real, allocatable, intent(in)             :: parent_mask_var(:,:)
     integer, intent(in)                         :: mask_val
     real*8, intent(in)                          :: default_val(low_z:high_z)
+    real*8, intent(in), optional                :: missing_val(low_z:high_z)
+
+    ! Local variables
+    real*8                                      :: missloc_val(low_z:high_z)
 
     real*8, dimension(:,:,:), allocatable :: nbuffer, sbuffer, ebuffer, wbuffer
     type(bbox)                          :: north_fine, north_coarse
@@ -676,6 +709,12 @@ contains
     type(bbox)                          :: west_fine, west_coarse
     integer                             :: this_pe
     integer                             :: nest_level = 1  ! TODO allow to vary
+
+    if (present(missing_val)) then
+      missloc_val = missing_val
+    else
+      missloc_val = default_val
+    endif
 
     this_pe = mpp_pe()
 
@@ -701,10 +740,10 @@ contains
       !!
       !!===========================================================
 
-      call fill_nest_from_buffer_masked(var_name, interp_type, data_var, nbuffer, north_fine, north_coarse, low_z, high_z, NORTH, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_val)
-      call fill_nest_from_buffer_masked(var_name, interp_type, data_var, sbuffer, south_fine, south_coarse, low_z, high_z, SOUTH, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_val)
-      call fill_nest_from_buffer_masked(var_name, interp_type, data_var, ebuffer, east_fine, east_coarse, low_z, high_z, EAST, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_val)
-      call fill_nest_from_buffer_masked(var_name, interp_type, data_var, wbuffer, west_fine, west_coarse, low_z, high_z, WEST, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_val)
+      call fill_nest_from_buffer_masked(var_name, interp_type, data_var, nbuffer, north_fine, north_coarse, low_z, high_z, NORTH, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_val, missloc_val)
+      call fill_nest_from_buffer_masked(var_name, interp_type, data_var, sbuffer, south_fine, south_coarse, low_z, high_z, SOUTH, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_val, missloc_val)
+      call fill_nest_from_buffer_masked(var_name, interp_type, data_var, ebuffer, east_fine, east_coarse, low_z, high_z, EAST, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_val, missloc_val)
+      call fill_nest_from_buffer_masked(var_name, interp_type, data_var, wbuffer, west_fine, west_coarse, low_z, high_z, WEST, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_val, missloc_val)
 
     endif
 
@@ -715,7 +754,7 @@ contains
 
   end subroutine fill_nest_halos_from_parent_masked_r8_3d_lowhighz_1d
 
-  subroutine fill_nest_halos_from_parent_masked_r8_3d_lowhighz_2d(var_name, data_var, interp_type, wt, ind, x_refine, y_refine, is_fine_pe, nest_domain, position, low_z, high_z, mask_var, parent_mask_var, mask_val, default_grid)
+  subroutine fill_nest_halos_from_parent_masked_r8_3d_lowhighz_2d(var_name, data_var, interp_type, wt, ind, x_refine, y_refine, is_fine_pe, nest_domain, position, low_z, high_z, mask_var, parent_mask_var, mask_val, default_grid, missing_grid)
     character(len=*), intent(in)                :: var_name
     real*8, allocatable, intent(inout)          :: data_var(:,:,:)
     integer, intent(in)                         :: interp_type
@@ -728,7 +767,11 @@ contains
     real, allocatable, intent(in)             :: mask_var(:,:)
     real, allocatable, intent(in)             :: parent_mask_var(:,:)
     integer, intent(in)                         :: mask_val
-    real, allocatable, intent(in)               :: default_grid(:,:)
+    real*8, allocatable, intent(in)             :: default_grid(:,:)
+    real*8, allocatable, intent(in), optional   :: missing_grid(:,:)
+
+    ! Local variables
+    real*8, allocatable                         :: missloc_grid(:,:)
 
     real*8, dimension(:,:,:), allocatable :: nbuffer, sbuffer, ebuffer, wbuffer
     type(bbox)                          :: north_fine, north_coarse
@@ -737,6 +780,13 @@ contains
     type(bbox)                          :: west_fine, west_coarse
     integer                             :: this_pe
     integer                             :: nest_level = 1  ! TODO allow to vary
+
+    allocate(missloc_grid, source=default_grid)
+    if (present(missing_grid)) then
+      missloc_grid = missing_grid
+    else
+      missloc_grid = default_grid
+    endif
 
     this_pe = mpp_pe()
 
@@ -762,10 +812,10 @@ contains
       !!
       !!===========================================================
 
-      call fill_nest_from_buffer_masked(var_name, interp_type, data_var, nbuffer, north_fine, north_coarse, low_z, high_z, NORTH, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_grid)
-      call fill_nest_from_buffer_masked(var_name, interp_type, data_var, sbuffer, south_fine, south_coarse, low_z, high_z, SOUTH, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_grid)
-      call fill_nest_from_buffer_masked(var_name, interp_type, data_var, ebuffer, east_fine, east_coarse, low_z, high_z, EAST, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_grid)
-      call fill_nest_from_buffer_masked(var_name, interp_type, data_var, wbuffer, west_fine, west_coarse, low_z, high_z, WEST, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_grid)
+      call fill_nest_from_buffer_masked(var_name, interp_type, data_var, nbuffer, north_fine, north_coarse, low_z, high_z, NORTH, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_grid, missloc_grid)
+      call fill_nest_from_buffer_masked(var_name, interp_type, data_var, sbuffer, south_fine, south_coarse, low_z, high_z, SOUTH, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_grid, missloc_grid)
+      call fill_nest_from_buffer_masked(var_name, interp_type, data_var, ebuffer, east_fine, east_coarse, low_z, high_z, EAST, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_grid, missloc_grid)
+      call fill_nest_from_buffer_masked(var_name, interp_type, data_var, wbuffer, west_fine, west_coarse, low_z, high_z, WEST, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_grid, missloc_grid)
 
     endif
 
@@ -773,6 +823,7 @@ contains
     deallocate(sbuffer)
     deallocate(ebuffer)
     deallocate(wbuffer)
+    deallocate(missloc_grid)
 
   end subroutine fill_nest_halos_from_parent_masked_r8_3d_lowhighz_2d
 
@@ -1774,7 +1825,7 @@ contains
 
   end subroutine fill_nest_from_buffer_r8_2d
 
-  subroutine fill_nest_from_buffer_masked_r8_2d_const(var_name, interp_type, x, buffer, bbox_fine, bbox_coarse, dir, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_val)
+  subroutine fill_nest_from_buffer_masked_r8_2d_const(var_name, interp_type, x, buffer, bbox_fine, bbox_coarse, dir, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_val, missing_val)
     implicit none
     character(len=*), intent(in)                :: var_name
     integer, intent(in)                         :: interp_type
@@ -1788,6 +1839,7 @@ contains
     real, allocatable, intent(in)               :: parent_mask_var(:,:)
     integer, intent(in)                         :: mask_val
     real*8, intent(in)                          :: default_val
+    real*8, intent(in)                          :: missing_val
 
     integer   :: this_pe
     this_pe = mpp_pe()
@@ -1802,7 +1854,7 @@ contains
       print '("[WARN] fv_moving_nest_utils.F90 fill_nest_from_buffer_mask interp_type 4 not implemented. var_name=",A16)', var_name
       call fill_nest_from_buffer_cell_center("D", x, buffer, bbox_fine, bbox_coarse, dir, x_refine, y_refine, wt, ind)
     case (7)
-      call fill_nest_from_buffer_cell_center_masked(var_name, "A", x, buffer, bbox_fine, bbox_coarse, dir, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_val)
+      call fill_nest_from_buffer_cell_center_masked(var_name, "A", x, buffer, bbox_fine, bbox_coarse, dir, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_val, missing_val)
     case (9)
       !call fill_nest_from_buffer_nearest_neighbor(x, buffer, bbox_fine, bbox_coarse, dir, wt)
       call mpp_error(FATAL, '2D fill_nest_from_buffer_nearest_neighbor not yet implemented.')
@@ -1812,7 +1864,7 @@ contains
 
   end subroutine fill_nest_from_buffer_masked_r8_2d_const
 
-  subroutine fill_nest_from_buffer_masked_r8_2d_2d(var_name, interp_type, x, buffer, bbox_fine, bbox_coarse, dir, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_grid)
+  subroutine fill_nest_from_buffer_masked_r8_2d_2d(var_name, interp_type, x, buffer, bbox_fine, bbox_coarse, dir, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_grid, missing_grid)
     implicit none
     character(len=*), intent(in)                :: var_name
     integer, intent(in)                         :: interp_type
@@ -1825,7 +1877,8 @@ contains
     real, allocatable, intent(in)               :: mask_var(:,:)
     real, allocatable, intent(in)               :: parent_mask_var(:,:)
     integer, intent(in)                         :: mask_val
-    real, allocatable, intent(in)               :: default_grid(:,:)
+    real*8, allocatable, intent(in)             :: default_grid(:,:)
+    real*8, allocatable, intent(in)             :: missing_grid(:,:)
 
     integer   :: this_pe
     this_pe = mpp_pe()
@@ -1840,7 +1893,7 @@ contains
       print '("[WARN] fv_moving_nest_utils.F90 fill_nest_from_buffer_mask interp_type 4 not implemented. var_name=",A16)', var_name
       call fill_nest_from_buffer_cell_center("D", x, buffer, bbox_fine, bbox_coarse, dir, x_refine, y_refine, wt, ind)
     case (7)
-      call fill_nest_from_buffer_cell_center_masked(var_name, "A", x, buffer, bbox_fine, bbox_coarse, dir, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_grid)
+      call fill_nest_from_buffer_cell_center_masked(var_name, "A", x, buffer, bbox_fine, bbox_coarse, dir, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_grid, missing_grid)
     case (9)
       !call fill_nest_from_buffer_nearest_neighbor(x, buffer, bbox_fine, bbox_coarse, dir, wt)
       call mpp_error(FATAL, '2D fill_nest_from_buffer_nearest_neighbor not yet implemented.')
@@ -1850,7 +1903,7 @@ contains
 
   end subroutine fill_nest_from_buffer_masked_r8_2d_2d
 
-  subroutine fill_nest_from_buffer_masked_r8_3d_1d(var_name, interp_type, x, buffer, bbox_fine, bbox_coarse, low_z, high_z, dir, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_vector)
+  subroutine fill_nest_from_buffer_masked_r8_3d_1d(var_name, interp_type, x, buffer, bbox_fine, bbox_coarse, low_z, high_z, dir, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_vector, missing_vector)
     implicit none
     character(len=*), intent(in)                :: var_name
     integer, intent(in)                         :: interp_type
@@ -1864,6 +1917,7 @@ contains
     real, allocatable, intent(in)               :: parent_mask_var(:,:)
     integer, intent(in)                         :: mask_val
     real*8, intent(in)                          :: default_vector(low_z:high_z)
+    real*8, intent(in)                          :: missing_vector(low_z:high_z)
 
     integer   :: this_pe
     this_pe = mpp_pe()
@@ -1880,7 +1934,7 @@ contains
       call mpp_error(FATAL, '3D fill_nest_from_buffer_nearest_neighbor not yet implemented.')
       !call fill_nest_from_buffer_cell_center("D", x, buffer, bbox_fine, bbox_coarse, dir, x_refine, y_refine, wt, ind)
     case (7)
-      call fill_nest_from_buffer_cell_center_masked(var_name, "A", x, buffer, bbox_fine, bbox_coarse, dir, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, low_z, high_z, default_vector)
+      call fill_nest_from_buffer_cell_center_masked(var_name, "A", x, buffer, bbox_fine, bbox_coarse, dir, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, low_z, high_z, default_vector, missing_vector)
     case (9)
       !call fill_nest_from_buffer_nearest_neighbor(x, buffer, bbox_fine, bbox_coarse, dir, wt)
       call mpp_error(FATAL, '3D fill_nest_from_buffer_nearest_neighbor not yet implemented.')
@@ -1890,7 +1944,7 @@ contains
 
   end subroutine fill_nest_from_buffer_masked_r8_3d_1d
 
-  subroutine fill_nest_from_buffer_masked_r8_3d_2d(var_name, interp_type, x, buffer, bbox_fine, bbox_coarse, low_z, high_z, dir, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_grid)
+  subroutine fill_nest_from_buffer_masked_r8_3d_2d(var_name, interp_type, x, buffer, bbox_fine, bbox_coarse, low_z, high_z, dir, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_grid, missing_grid)
     implicit none
     character(len=*), intent(in)                :: var_name
     integer, intent(in)                         :: interp_type
@@ -1903,7 +1957,8 @@ contains
     real, allocatable, intent(in)               :: mask_var(:,:)
     real, allocatable, intent(in)               :: parent_mask_var(:,:)
     integer, intent(in)                         :: mask_val
-    real, allocatable, intent(in)               :: default_grid(:,:)
+    real*8, allocatable, intent(in)             :: default_grid(:,:)
+    real*8, allocatable, intent(in)             :: missing_grid(:,:)
 
     integer   :: this_pe
     this_pe = mpp_pe()
@@ -1920,7 +1975,7 @@ contains
       call mpp_error(FATAL, '3D fill_nest_from_buffer_nearest_neighbor not yet implemented.')
       !call fill_nest_from_buffer_cell_center("D", x, buffer, bbox_fine, bbox_coarse, dir, x_refine, y_refine, wt, ind)
     case (7)
-      call fill_nest_from_buffer_cell_center_masked(var_name, "A", x, buffer, bbox_fine, bbox_coarse, dir, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, low_z, high_z, default_grid)
+      call fill_nest_from_buffer_cell_center_masked(var_name, "A", x, buffer, bbox_fine, bbox_coarse, dir, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, low_z, high_z, default_grid, missing_grid)
     case (9)
       !call fill_nest_from_buffer_nearest_neighbor(x, buffer, bbox_fine, bbox_coarse, dir, wt)
       call mpp_error(FATAL, '3D fill_nest_from_buffer_nearest_neighbor not yet implemented.')
@@ -2178,7 +2233,7 @@ contains
 
   end subroutine fill_nest_from_buffer_cell_center_r8_2d
 
-  subroutine fill_nest_from_buffer_cell_center_masked_2d_const(var_name, stagger, x, buffer, bbox_fine, bbox_coarse, dir, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_val)
+  subroutine fill_nest_from_buffer_cell_center_masked_2d_const(var_name, stagger, x, buffer, bbox_fine, bbox_coarse, dir, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_val, missing_val)
     implicit none
     character(len=*), intent(in)                  :: var_name
     character ( len = 1 ), intent(in)             :: stagger
@@ -2192,6 +2247,7 @@ contains
     real, allocatable, intent(in)                 :: parent_mask_var(:,:)
     integer, intent(in)                           :: mask_val
     real*8, intent(in)                            :: default_val
+    real*8, intent(in)                            :: missing_val
 
     character(len=8)       :: dir_str
     integer                :: i, j, k, ic, jc
@@ -2302,13 +2358,14 @@ contains
 
           endif
 
-          if (tw .gt. 0.0) then
-            x(i,j) = x(i,j) / tw
+          if (mask_var(i,j) .eq. mask_val) then
+            if (tw .gt. 0.0) then
+              x(i,j) = x(i,j) / tw
+            else
+              x(i,j) = default_val
+            endif
           else
-            num_reset = num_reset + 1
-            dummy_val = buffer(ic, jc)
-            dummy_mask = mask_var(i,j)
-            x(i,j) = default_val
+            x(i,j) = missing_val
           endif
 
           !if ( this_pe .eq. 89 .and. trim(var_name) .eq. "snowxy") print '("[INFO] MASK_SNOWXY 2d_const npe=",I0," num_weights=",I0," x(",I0,",",I0,")=",E12.5)', this_pe, num_weights, i, j, x(i,j)
@@ -2321,7 +2378,7 @@ contains
 
   end subroutine fill_nest_from_buffer_cell_center_masked_2d_const
 
-  subroutine fill_nest_from_buffer_cell_center_masked_2d_2d(var_name, stagger, x, buffer, bbox_fine, bbox_coarse, dir, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_grid)
+  subroutine fill_nest_from_buffer_cell_center_masked_2d_2d(var_name, stagger, x, buffer, bbox_fine, bbox_coarse, dir, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, default_grid, missing_grid)
     implicit none
     character(len=*), intent(in)                  :: var_name
     character ( len = 1 ), intent(in)             :: stagger
@@ -2334,7 +2391,8 @@ contains
     real, allocatable, intent(in)                 :: mask_var(:,:)
     real, allocatable, intent(in)                 :: parent_mask_var(:,:)
     integer, intent(in)                           :: mask_val
-    real, allocatable, intent(in)                 :: default_grid(:,:)
+    real*8, allocatable, intent(in)               :: default_grid(:,:)
+    real*8, allocatable, intent(in)               :: missing_grid(:,:)
 
     character(len=8)       :: dir_str
     integer                :: i, j, k, ic, jc
@@ -2442,13 +2500,14 @@ contains
 
           endif
 
-          if (tw .gt. 0.0) then
-            x(i,j) = x(i,j) / tw
+          if (mask_var(i,j) .eq. mask_val) then
+            if (tw .gt. 0.0) then
+              x(i,j) = x(i,j) / tw
+            else
+              x(i,j) = default_grid(i,j)
+            endif
           else
-            num_reset = num_reset + 1
-            dummy_val = buffer(ic, jc)
-            dummy_mask = mask_var(i,j)
-            x(i,j) = default_grid(i,j)
+            x(i,j) = missing_grid(i,j)
           endif
 
           !if ( this_pe .eq. 89 .and. trim(var_name) .eq. "snowxy") print '("[INFO] MASK_SNOWXY 2d_2d npe=",I0," num_weights=",I0," x(",I0,",",I0,")=",E12.5)', this_pe, num_weights, i, j, x(i,j)
@@ -2461,7 +2520,7 @@ contains
 
   end subroutine fill_nest_from_buffer_cell_center_masked_2d_2d
 
-  subroutine fill_nest_from_buffer_cell_center_masked_3d_1d(var_name, stagger, x, buffer, bbox_fine, bbox_coarse, dir, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, low_z, high_z, default_vector)
+  subroutine fill_nest_from_buffer_cell_center_masked_3d_1d(var_name, stagger, x, buffer, bbox_fine, bbox_coarse, dir, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, low_z, high_z, default_vector, missing_vector)
     implicit none
     character(len=*), intent(in)                  :: var_name
     character ( len = 1 ), intent(in)             :: stagger
@@ -2475,6 +2534,7 @@ contains
     real, allocatable, intent(in)                 :: parent_mask_var(:,:)
     integer, intent(in)                           :: mask_val, low_z, high_z
     real*8, intent(in)                            :: default_vector(low_z:high_z)
+    real*8, intent(in)                            :: missing_vector(low_z:high_z)
 
     character(len=8)       :: dir_str
     integer                :: i, j, k, ic, jc
@@ -2539,12 +2599,14 @@ contains
               tw = tw + wt(i,j,4)
             endif
 
-            if (tw .gt. 0.0) then
-              x(i,j,k) = x(i,j,k) / tw
+            if (mask_var(i,j) .eq. mask_val) then
+              if (tw .gt. 0.0) then
+                x(i,j,k) = x(i,j,k) / tw
+              else
+                x(i,j,k) = default_vector(k)
+              endif
             else
-              dummy_val = buffer(ic, jc,k)
-              dummy_mask = mask_var(i,j)
-              x(i,j,k) = default_vector(k)
+              x(i,j,k) = missing_vector(k)
             endif
 
           enddo
@@ -2559,7 +2621,7 @@ contains
 
   end subroutine fill_nest_from_buffer_cell_center_masked_3d_1d
 
-  subroutine fill_nest_from_buffer_cell_center_masked_3d_2d(var_name, stagger, x, buffer, bbox_fine, bbox_coarse, dir, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, low_z, high_z, default_grid)
+  subroutine fill_nest_from_buffer_cell_center_masked_3d_2d(var_name, stagger, x, buffer, bbox_fine, bbox_coarse, dir, x_refine, y_refine, wt, ind, mask_var, parent_mask_var, mask_val, low_z, high_z, default_grid, missing_grid)
     implicit none
     character(len=*), intent(in)                  :: var_name
     character ( len = 1 ), intent(in)             :: stagger
@@ -2572,7 +2634,8 @@ contains
     real, allocatable, intent(in)                 :: mask_var(:,:)
     real, allocatable, intent(in)                 :: parent_mask_var(:,:)
     integer, intent(in)                           :: mask_val, low_z, high_z
-    real, allocatable, intent(in)                 :: default_grid(:,:)
+    real*8, allocatable, intent(in)               :: default_grid(:,:)
+    real*8, allocatable, intent(in)               :: missing_grid(:,:)
 
     character(len=8)       :: dir_str
     integer                :: i, j, k, ic, jc
@@ -2637,12 +2700,14 @@ contains
               tw = tw + wt(i,j,4)
             endif
 
-            if (tw .gt. 0.0) then
-              x(i,j,k) = x(i,j,k) / tw
+            if (mask_var(i,j) .eq. mask_val) then
+              if (tw .gt. 0.0) then
+                x(i,j,k) = x(i,j,k) / tw
+              else
+                x(i,j,k) = default_grid(i,j)
+              endif
             else
-              dummy_val = buffer(ic, jc,k)
-              dummy_mask = mask_var(i,j)
-              x(i,j,k) = default_grid(i,j)
+              x(i,j,k) = missing_grid(i,j)
             endif
 
           enddo


### PR DESCRIPTION
Mainly based on checking/testing/discussion and working sessions among @barlage, @wramstrom, @RongqianYang-NOAA, @ChuankaiWang-NOAA, @BijuThomas-NOAA, @BinLiu-NOAA.
 - Improve the fill_nest_halos_from_parent_masked interface to handle both default and missing/fill values; Update and properly set default and missing values for related varialbes. (@wramstrom, @BinLiu-NOAA)
 - Update and properly set default and missing values for some NoahMP LSM varialbes. (@barlage, @wramstrom, @BinLiu-NOAA)
 - Add handling additional variables for nest moving: srflag, snodl, weasdl, snodi, weasdi, and zorli. (@ChuankaiWang-NOAA, @BinLiu-NOAA)